### PR TITLE
Fix skill registration types and forward visibility

### DIFF
--- a/sourcemod/scripting/include/rage/skills.inc
+++ b/sourcemod/scripting/include/rage/skills.inc
@@ -22,7 +22,7 @@ stock bool RageSkills_IsAvailable()
     return LibraryExists(RAGE_PLUGIN_NAME);
 }
 
-stock void RageSkills_Refresh(const char[] skillName, int skillType, int &skillId, bool &available)
+stock void RageSkills_Refresh(char[] skillName, int skillType, int &skillId, bool &available)
 {
     available = RageSkills_IsAvailable();
     if (available && skillId == -1)
@@ -31,7 +31,7 @@ stock void RageSkills_Refresh(const char[] skillName, int skillType, int &skillI
     }
 }
 
-stock void RageSkills_OnLibraryAdded(const char[] name, const char[] skillName, int skillType, int &skillId, bool &available)
+stock void RageSkills_OnLibraryAdded(const char[] name, char[] skillName, int skillType, int &skillId, bool &available)
 {
     if (StrEqual(name, RAGE_PLUGIN_NAME, false))
     {

--- a/sourcemod/scripting/rage_survivor_menu.sp
+++ b/sourcemod/scripting/rage_survivor_menu.sp
@@ -334,7 +334,7 @@ bool TryShowGuideMenu(int client)
     return true;
 }
 
-void AddGameModeOptions(int menu_id)
+public void AddGameModeOptions(int menu_id)
 {
     char options[512];
     options[0] = '\0';

--- a/sourcemod/scripting/rage_survivor_plugin_grenades.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_grenades.sp
@@ -272,7 +272,9 @@
 
 
 //Rage
+#if !defined REQUIRE_PLUGIN
 #define REQUIRE_PLUGIN
+#endif
 #tryinclude <RageCore>
 
 #if !defined _RageCore_included
@@ -975,28 +977,34 @@ public void OnAllPluginsLoaded()
 
 public void OnLibraryAdded(const char[] sName)
 {
-else if( strcmp(sName, "left4dhooks") == 0 )
-g_bLeft4DHooks = true;
-    else if( strcmp(sName, "rage_survivor") == 0 )
-Rage_Available = true;
-	else if( g_bLeft4Dead2 && strcmp(sName, "l4d2_airstrike") == 0 )
-	{
-		g_bAirstrike = true;
-		// Assuming valid for late load
-		if( g_bLateLoad )
-			g_bAirstrikeValid = true;
-	}
+        if( strcmp(sName, "left4dhooks") == 0 )
+        {
+                g_bLeft4DHooks = true;
+        }
+        else if( strcmp(sName, "rage_survivor") == 0 )
+        {
+                Rage_Available = true;
+        }
+        else if( g_bLeft4Dead2 && strcmp(sName, "l4d2_airstrike") == 0 )
+        {
+                g_bAirstrike = true;
+                // Assuming valid for late load
+                if( g_bLateLoad )
+                        g_bAirstrikeValid = true;
+        }
 }
 public void OnLibraryRemoved(const char[] sName)
 {
-else if( strcmp(sName, "left4dhooks") == 0 )
-g_bLeft4DHooks = false;
-   else if( strcmp(sName, "rage_survivor") == 0 ) {
-		Rage_Available = false;
-		g_iClassID = -1;
-	}
-	else if( g_bLeft4Dead2 && strcmp(sName, "l4d2_airstrike") == 0 )
-		g_bAirstrike = true;
+        if( strcmp(sName, "left4dhooks") == 0 )
+        {
+                g_bLeft4DHooks = false;
+        }
+        else if( strcmp(sName, "rage_survivor") == 0 ) {
+                Rage_Available = false;
+                g_iClassID = -1;
+        }
+        else if( g_bLeft4Dead2 && strcmp(sName, "l4d2_airstrike") == 0 )
+                g_bAirstrike = true;
 }
 
 public void OnPluginEnd()


### PR DESCRIPTION
## Summary
- mark AddGameModeOptions as public to match the forward signature
- adjust rage skill helper parameter types to match RegisterRageSkill expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d44d4bfc8326971bbbe480492ca6)