### PR TITLE
Add parachute model fallbacks to movement helper

### DIFF
--- a/sourcemod/scripting/include/rage/movement.inc
+++ b/sourcemod/scripting/include/rage/movement.inc
@@ -45,6 +45,8 @@ enum struct ParachuteAbility
 
     bool HandleRunCmd(int client, int buttons, int flags, Handle parachuteToggle, bool isLeft4Dead2)
     {
+        #pragma unused flags
+
         if (!GetConVarBool(parachuteToggle))
         {
             return false;

--- a/sourcemod/scripting/include/rage/movement.inc
+++ b/sourcemod/scripting/include/rage/movement.inc
@@ -7,6 +7,16 @@
     #define SOUND_HELICOPTER "vehicles/airboat/fan_blade_fullthrottle_loop1.wav"
 #endif
 
+// Provide local fallbacks for common models used by the parachute ability so this
+// helper can be included without relying on broader talent definitions.
+#if !defined PARACHUTE
+    #define PARACHUTE "models/props_swamp/parachute01.mdl"
+#endif
+
+#if !defined FAN_BLADE
+    #define FAN_BLADE "models/props/de_inferno/ceiling_fan_blade.mdl"
+#endif
+
 /**
  * Lightweight containers for movement-centric abilities so they can be reused
  * from talent classes without cluttering the primary plugin file.


### PR DESCRIPTION
## Summary
- add local parachute and fan blade model definitions in movement helper
- allow parachute helper to be included without relying on external talent definitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229318ae008326ad43b417a510c556)