### PR TITLE
Rename prototype grenades references

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Rage Edition grew out of DLR keeps a mix of community talent and community open-
 
 - Core talents and class system by DLR team, Ken, Neil, Spirit, panxiaohai, and Yani.
 - Scripted HUD work by Mart and Yani.
-- Extra menu system, airstrike, prototype grenades, and Left 4 DHooks utilities by SilverShot (Silvers).
+- Extra menu system, airstrike, grenades, and Left 4 DHooks utilities by SilverShot (Silvers).
 - Satellite cannon plugin by ztar.
 - Music player by Dragokas.
 - Tutorial guide and Dead Ringer cloak by Yani and Shadowysn.

--- a/sourcemod/scripting/include/left4dhooks.inc
+++ b/sourcemod/scripting/include/left4dhooks.inc
@@ -4597,7 +4597,7 @@ native int L4D_GetGameModeType();
 
 /**
  * @brief Deafens a player with a high pitch ringing sound for a few seconds
- * @remarks Used in the "Prototype Grenades" plugin by Silvers
+ * @remarks Used in the "Grenades" plugin by Silvers
  *
  * @param client	Client id of the player to deafen
  *

--- a/sourcemod/scripting/rage_survivor_guide.sp
+++ b/sourcemod/scripting/rage_survivor_guide.sp
@@ -491,7 +491,7 @@ void DisplaySkillMenu(int client)
     Menu menu = CreateMenu(MenuHandler_Skills);
     SetMenuTitle(menu, "Special Skills & Commands");
     AddMenuItem(menu, "skill", "Class skill command");
-    AddMenuItem(menu, "grenades", "Prototype grenades");
+    AddMenuItem(menu, "grenades", "Grenades");
     AddMenuItem(menu, "healingorb", "Healing orb toss");
     AddMenuItem(menu, "deadringer", "Dead Ringer");
     AddMenuItem(menu, "sight", "Extended sight");
@@ -519,7 +519,7 @@ public int MenuHandler_Skills(Menu menu, MenuAction action, int param1, int para
             }
             else if (StrEqual(info, "grenades"))
             {
-                PrintGuideLine(param1, "Equip any grenade, hold FIRE and tap SHOVE (or use sm_grenade) to cycle through experimental prototypes.");
+                PrintGuideLine(param1, "Equip any grenade, hold FIRE and tap SHOVE (or use sm_grenade) to cycle through grenade types.");
             }
             else if (StrEqual(info, "healingorb"))
             {

--- a/sourcemod/scripting/rage_survivor_plugin_grenades.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_grenades.sp
@@ -1,5 +1,5 @@
 /*
-*	Prototype Grenades
+*	Grenades
 *	Copyright (C) 2022 Silvers
 *
 *	This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,7 @@
 /*======================================================================================
 	Plugin Info:
 
-*	Name	:	[L4D & L4D2] Prototype Grenades Plugin version
+*	Name	:	[L4D & L4D2] Grenades Plugin version
 *	Author	:	SilverShot
 *	Descrp	:	Creates a selection of different grenade types.
 
@@ -66,7 +66,7 @@
 	- Requested by "Darkwob"
 
 1.37 (04-Jun-2021)
-	- Now tests if clients have access to the "sm_grenade" command to restrict Prototype Grenades to specific users. Requested by "Darkwob".
+	- Now tests if clients have access to the "sm_grenade" command to restrict Grenades to specific users. Requested by "Darkwob".
 	- Use the "sourcemod/configs/admin_overrides.cfg" to modify the command flags required.
 	- Data config change: "Tesla" and "Black Hole" types no longer create a shake on explosion.
 
@@ -230,7 +230,7 @@
 	- Some optimizations.
 
 1.1 (08-Oct-2019)
-	- Added "bots" in the config to control if bots can use Prototype Grenades. Requires external plugin.
+	- Added "bots" in the config to control if bots can use Grenades. Requires external plugin.
 	- Added "damage_special", "damage_survivors", "damage_tank", "damage_witch" and "damage_physics" in the config to scale damage.
 	- Added "preferences" in the config to save a players selected mode, or give a random grenade type. Persistent with dropping.
 	- Added "targets" in the config to control who can be affected by the grenade effects.
@@ -535,7 +535,7 @@ float	g_fConfigAcidSurv;											// Chemical Mode - Acid damage - Survivors
 float	g_fConfigGlowBonus;											// Glow mode - damage bonus
 float	g_fConfigFreezeTime;										// Freeze mode - freeze time
 int		g_iConfigDmgType;											// Damage type. Only used for Flak type.
-int		g_iConfigBots;												// Can bots use Prototype Grenades
+int		g_iConfigBots;												// Can bots use Grenades
 int		g_iConfigStock;												// Which grenades have their default feature.
 int		g_iConfigTypes;												// Which grenade modes are allowed.
 int		g_iConfigBinds;												// Menu or Pressing keys to change mode.
@@ -638,7 +638,7 @@ enum
 // ====================================================================================================
 public Plugin myinfo =
 {
-	name = "[Rage] Prototype Grenades plugin",
+	name = "[Rage] Grenades plugin",
 	author = "SilverShot",
 	description = "Creates a selection of different grenade types.",
 	version = PLUGIN_VERSION,
@@ -807,7 +807,7 @@ public void OnPluginStart()
 	g_hCvarModes = CreateConVar(	"l4d_grenades_modes",			"",						"Turn on the plugin in these game modes, separate by commas (no spaces). (Empty = all).", CVAR_FLAGS );
 	g_hCvarModesOff = CreateConVar(	"l4d_grenades_modes_off",		"",						"Turn off the plugin in these game modes, separate by commas (no spaces). (Empty = none).", CVAR_FLAGS );
 	g_hCvarModesTog = CreateConVar(	"l4d_grenades_modes_tog",		"1",					"Turn on the plugin in these game modes. 0=All, 1=Coop, 2=Survival, 4=Versus, 8=Scavenge. Add numbers together.", CVAR_FLAGS );
-	CreateConVar(					"l4d_grenades_version",			PLUGIN_VERSION,			"Prototype Grenades plugin version.", FCVAR_NOTIFY|FCVAR_DONTRECORD);
+	CreateConVar(					"l4d_grenades_version",			PLUGIN_VERSION,			"Grenades plugin version.", FCVAR_NOTIFY|FCVAR_DONTRECORD);
 	AutoExecConfig(true,			"l4d_grenades");
 
 	g_hDecayDecay = FindConVar("pain_pills_decay_rate");
@@ -868,7 +868,7 @@ public void OnPluginStart()
 	LoadTranslations("rage_grenades.phrases");
 
 	// Saved client options
-	g_hCookie = RegClientCookie("l4d_grenades_modes", "Prototype Grenades - Modes", CookieAccess_Protected);
+	g_hCookie = RegClientCookie("l4d_grenades_modes", "Grenades - Modes", CookieAccess_Protected);
 
 	// Max char health
 	m_maxHealth = FindSendPropInfo("CTerrorPlayerResource", "m_maxHealth");
@@ -2129,7 +2129,7 @@ Action SoundHook(int clients[64], int &numClients, char sample[PLATFORM_MAX_PATH
 		}
 	}
 
-	// Replace Prototype Grenades bounce sound.
+	// Replace Grenades bounce sound.
 	// weapons/hegrenade/he_bounce-1.wav
 	if( sample[0] == 'w' && sample[8] == 'h' && sample[18] == 'h' )
 	{
@@ -2145,7 +2145,7 @@ Action SoundHook(int clients[64], int &numClients, char sample[PLATFORM_MAX_PATH
 	}
 
 	// L4D2 survivors only.
-	// Change players saying "throwing molotov" or "throwing pipebomb" to "throwing grenade" when a Prototype Grenade mode is selected.
+        // Change players saying "throwing molotov" or "throwing pipebomb" to "throwing grenade" when a Grenade mode is selected.
 
 	// Info for anyone who reads:
 	// Players can vocalize from other objects, eg an "info_target" entity (see Mic plugin) and not a client index.

--- a/sourcemod/translations/rage_grenades.phrases.txt
+++ b/sourcemod/translations/rage_grenades.phrases.txt
@@ -3,7 +3,7 @@
 	// Valid colors: {orange} {green} {cyan} {white}
 	"GrenadeMenu_Title"
 	{
-		"en"			"Prototype Grenades"
+		"en"			"Grenades"
 	}
 	"GrenadeMenu_Invalid"
 	{


### PR DESCRIPTION
## Summary
- Update survivor guide menus and translations to use the Grenades label
- Refresh plugin metadata, documentation comments, and credits to drop the Prototype prefix
- Keep grenades helper text consistent with the renamed feature

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235a537e6c8326899427e62538309a)