### PR TITLE
Add configurable skill action bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A celebratory remix of Left 4 Dead 2 DLR Mode that turns every round into a play
 ## Core Features
 - Sourcemod 1.12 compatible
 - Plugin-based architecture: drop in new perks or classes via `RageCore` and optional skill plugins
-- Configurable skill bindings per class via `configs/rage_class_skills.cfg` (special, secondary, deploy)
+- Configurable skill bindings per class via `configs/rage_class_skills.cfg` (special, secondary, tertiary, deploy)
 - Modular perk system with negative effects and combo chaining; class-based skins and custom class definitions.
 - New menu system. Hold ALT to show menu, move and select with WASD keys. Release ALT to exit.
 - Additional admin menu aligned with the new menu system
@@ -22,8 +22,18 @@ A celebratory remix of Left 4 Dead 2 DLR Mode that turns every round into a play
 
 ## Play your way
 
-- Players have 3 extra skill actions + deploy action. These are configurable. 
-- Deploy action is mapped to SHIFT. You can also deploy from quick menu
+- Players have 3 extra skill actions + deploy action. These are configurable.
+- Default inputs for the four actions are below; rebind them to your liking in `configs/rage_class_skills.cfg` or via your own keybinds.
+
+| Action               | Default input              | Notes |
+| -------------------- | -------------------------- | ----- |
+| `skill_action_1`     | Middle button              | Primary class action |
+| `skill_action_2`     | Use + Fire                 | Alternate class action |
+| `skill_action_3`     | Crouch + Use + Fire        | Extra class action |
+| `deployment_action`  | Look down and hold **Shift** | Deploy/place items |
+
+- You can trigger actions from the quick menu as well.
+- Update `configs/rage_skill_actions.cfg` if you remap these buttons so the in-game prompts match your binds.
 - Multiple equipment mode
 - You can configure the skills and add new ones
 
@@ -69,7 +79,7 @@ A celebratory remix of Left 4 Dead 2 DLR Mode that turns every round into a play
 - Reduced survivor damage, increased infected damage
 
 ## Additional Features & Commands
-- **Class Skill Command** – Bind a key or type `!skill` to trigger your class's special ability. Secondary actions (Use+Attack) and deploy actions (look down + Shift) are configurable per class in `configs/rage_class_skills.cfg`.
+- **Class Skill Actions** – Bind `skill_action_1` through `skill_action_3` and `deployment_action` to trigger your class's abilities. Inputs are fully configurable per class in `configs/rage_class_skills.cfg`.
 - Keeps chosen class throughout the campaign unless user changes it.
 
 ## Toys, tricks, and server spice

--- a/sourcemod/configs/rage_class_skills.cfg
+++ b/sourcemod/configs/rage_class_skills.cfg
@@ -8,12 +8,14 @@
         "soldier"
         {
                 "special"       "skill:Airstrike"
+                "tertiary"      "none"
                 "secondary"     "none"
                 "deploy"        "none"
         }
         "athlete"
         {
                 "special"       "command:Grenades:15"
+                "tertiary"      "none"
                 "secondary"     "none"
                 "deploy"        "none"
         }
@@ -21,11 +23,13 @@
         {
                 "special"       "skill:Grenades"
                 "secondary"     "skill:HealingOrb"
+                "tertiary"      "none"
                 "deploy"        "builtin:medic_supply"
         }
         "saboteur"
         {
                 "special"       "skill:cloak:1"
+                "tertiary"      "none"
                 "secondary"     "none"
                 "deploy"        "builtin:saboteur_mines"
         }
@@ -33,17 +37,20 @@
         {
                 "special"       "skill:Satellite"
                 "secondary"     "skill:Berzerk"
+                "tertiary"      "none"
                 "deploy"        "none"
         }
         "engineer"
         {
                 "special"       "skill:Multiturret"
                 "secondary"     "command:Grenades:7"
+                "tertiary"      "none"
                 "deploy"        "builtin:engineer_supply"
         }
         "brawler"
         {
                 "special"       "none"
+                "tertiary"      "none"
                 "secondary"     "none"
                 "deploy"        "none"
         }

--- a/sourcemod/configs/rage_skill_actions.cfg
+++ b/sourcemod/configs/rage_skill_actions.cfg
@@ -1,0 +1,9 @@
+"RageSkillActionBinds"
+{
+    // Controls the on-screen prompts for bound skill action buttons.
+    // Update the values below to match the keys you ask players to use.
+    "skill_action_1"      "Middle button"
+    "skill_action_2"      "Use + Fire"
+    "skill_action_3"      "Crouch + Use + Fire"
+    "deployment_action"   "Look down + SHIFT"
+}

--- a/sourcemod/scripting/include/rage/menus.inc
+++ b/sourcemod/scripting/include/rage/menus.inc
@@ -25,12 +25,10 @@ stock bool:CreatePlayerClassMenu(client)
 		return false;
 	}
 	
-	// if client has a class already and round has started, dont give them the menu
-	if (ClientData[client].ChosenClass != NONE && RoundStarted == true)
-	{
-		PrintToChat(client,"Round has started, your class is locked, You are a %s",MENU_OPTIONS[ClientData[client].ChosenClass]);
-		return false;
-	}
+        if (ClientData[client].ChosenClass != NONE && RoundStarted == true)
+        {
+                PrintToChat(client,"Round has started; pick a new class now and it will apply next round. You are a %s",MENU_OPTIONS[ClientData[client].ChosenClass]);
+        }
 	
 	if(IsClientInGame(client) && ClientData[client].ChosenClass == NONE && RoundStarted == false)
 	{
@@ -59,8 +57,8 @@ stock bool:CreatePlayerClassMenu(client)
 
 public PanelHandler_SelectClass(Handle:menu, MenuAction:action, client, param)
 {
-	ClassTypes OldClass;
-	OldClass = ClientData[client].ChosenClass;
+        ClassTypes OldClass;
+        OldClass = ClientData[client].ChosenClass;
 
 	switch (action)
 	{
@@ -78,33 +76,45 @@ public PanelHandler_SelectClass(Handle:menu, MenuAction:action, client, param)
 			} 
 			else
 			{
-				//DrawConfirmPanel(client, param);
-				
-				LastClassConfirmed[client] = param;
-				ClientData[client].ChosenClass = view_as<ClassTypes>(param);	
+                                bool classLocked = (RoundStarted == true && OldClass != NONE);
+                                ClassTypes newClass = view_as<ClassTypes>(param);
 
-				// Inform other plugins.
-				Call_StartForward(g_hfwdOnPlayerClassChange);
-				Call_PushCell(client);
-				Call_PushCell(ClientData[client].ChosenClass);
-				Call_PushCell(LastClassConfirmed[client]);
-				Call_Finish();				
+                                if (classLocked)
+                                {
+                                        g_iQueuedClass[client] = param;
+                                        SaveClassCookie(client, newClass);
+                                        PrintToChat(client, "%sYou will switch to %s next round. Use the menu again if you want a different class.", PRINT_PREFIX, MENU_OPTIONS[param]);
+                                        return;
+                                }
 
-				PrintToConsole(client, "Class is setting up");
-				
-				SetupClasses(client, param);
-				EmitSoundToClient(client, SOUND_CLASS_SELECTED);
-				RebuildCache();
-				if(view_as<int>(OldClass) == 0)
-				{
-					PrintToChatAll("\x04%N\x01 is a \x05%s\x01%s",client,MENU_OPTIONS[param],ClassTips[param]);
-				}	
-				else
-				{
-					PrintToChatAll("\x04%N\x01 : class changed from \x05%s\x01 to \x05%s\x01",client,MENU_OPTIONS[OldClass],MENU_OPTIONS[param]);
-				}
-			}
-		}
+                                g_iQueuedClass[client] = 0;
+                                LastClassConfirmed[client] = param;
+                                ClientData[client].ChosenClass = newClass;
+                                SaveClassCookie(client, newClass);
+
+                                // Inform other plugins.
+                                Call_StartForward(g_hfwdOnPlayerClassChange);
+                                Call_PushCell(client);
+                                Call_PushCell(ClientData[client].ChosenClass);
+                                Call_PushCell(LastClassConfirmed[client]);
+                                Call_Finish();
+
+                                PrintToConsole(client, "Class is setting up");
+
+                                SetupClasses(client, param);
+                                EmitSoundToClient(client, SOUND_CLASS_SELECTED);
+                                RebuildCache();
+                                if(view_as<int>(OldClass) == 0)
+                                {
+                                        PrintToChatAll("\x04%N\x01 is a \x05%s\x01%s",client,MENU_OPTIONS[param],ClassTips[param]);
+                                }
+                                else
+                                {
+                                        PrintToChatAll("\x04%N\x01 : class changed from \x05%s\x01 to \x05%s\x01",client,MENU_OPTIONS[OldClass],MENU_OPTIONS[param]);
+                                }
+                                PrintToChat(client, "%sClass selected. Use the Rage menu to change it again.", PRINT_PREFIX);
+                        }
+                }
 		case MenuAction_Cancel:
 		{
 			CloseHandle(menu);

--- a/sourcemod/scripting/include/rage/skill_actions.inc
+++ b/sourcemod/scripting/include/rage/skill_actions.inc
@@ -1,0 +1,75 @@
+#if defined _RAGE_SKILL_ACTIONS_INC_
+ #endinput
+#endif
+#define _RAGE_SKILL_ACTIONS_INC_
+
+#define SKILL_ACTION_BIND_CONFIG "configs/rage_skill_actions.cfg"
+
+enum SkillActionSlot
+{
+    SkillAction_Primary = 0,
+    SkillAction_Secondary,
+    SkillAction_Tertiary,
+    SkillAction_Deploy,
+    SkillActionSlot_Count
+};
+
+static const char g_SkillActionKeys[SkillActionSlot_Count][24] =
+{
+    "skill_action_1",
+    "skill_action_2",
+    "skill_action_3",
+    "deployment_action"
+};
+
+char g_SkillActionBindings[SkillActionSlot_Count][64];
+
+void ResetSkillActionBindings()
+{
+    strcopy(g_SkillActionBindings[SkillAction_Primary], sizeof(g_SkillActionBindings[]), "Middle button");
+    strcopy(g_SkillActionBindings[SkillAction_Secondary], sizeof(g_SkillActionBindings[]), "Use + Fire");
+    strcopy(g_SkillActionBindings[SkillAction_Tertiary], sizeof(g_SkillActionBindings[]), "Crouch + Use + Fire");
+    strcopy(g_SkillActionBindings[SkillAction_Deploy], sizeof(g_SkillActionBindings[]), "Look down + SHIFT");
+}
+
+void LoadSkillActionBindings()
+{
+    ResetSkillActionBindings();
+
+    char path[PLATFORM_MAX_PATH];
+    BuildPath(Path_SM, path, sizeof(path), SKILL_ACTION_BIND_CONFIG);
+    if (!FileExists(path))
+    {
+        return;
+    }
+
+    KeyValues kv = new KeyValues("RageSkillActionBinds");
+    if (!kv.ImportFromFile(path))
+    {
+        delete kv;
+        return;
+    }
+
+    for (int i = 0; i < view_as<int>(SkillActionSlot_Count); i++)
+    {
+        char value[64];
+        kv.GetString(g_SkillActionKeys[i], value, sizeof(value), "");
+        if (value[0] != '\0')
+        {
+            strcopy(g_SkillActionBindings[i], sizeof(g_SkillActionBindings[]), value);
+        }
+    }
+
+    delete kv;
+}
+
+void GetSkillActionBindingLabel(SkillActionSlot slot, char[] buffer, int maxlen)
+{
+    buffer[0] = '\0';
+    if (slot < 0 || slot >= SkillActionSlot_Count)
+    {
+        return;
+    }
+
+    strcopy(buffer, maxlen, g_SkillActionBindings[slot]);
+}

--- a/sourcemod/scripting/include/talents.inc
+++ b/sourcemod/scripting/include/talents.inc
@@ -155,7 +155,7 @@ stock int b_attackerTarget[MAXPLAYERS+1];
 // Player Related Variables
 
 new LastClassConfirmed[MAXPLAYERS+1];
-new int g_iQueuedClass[MAXPLAYERS+1];
+int g_iQueuedClass[MAXPLAYERS+1];
 new bool:g_bInSaferoom[MAXPLAYERS+1];
 new Float:g_SpawnPos[MAXPLAYERS+1][3];
 new bool:RoundStarted =false;

--- a/sourcemod/scripting/include/talents.inc
+++ b/sourcemod/scripting/include/talents.inc
@@ -5,6 +5,7 @@
 #include <sdktools>
 #include <sdkhooks>
 #include <left4dhooks>
+#include <clientprefs>
 #include <rage/const>
 #include <rage/debug>
 //#include <rage/classes>
@@ -21,6 +22,7 @@ new Handle:g_hfwdOnPlayerClassChange;
 new g_iSkillCounter = -1;
 new Handle:g_hSkillArray = INVALID_HANDLE;
 new Handle:g_hSkillTypeArray = INVALID_HANDLE;
+Handle g_hClassCookie = INVALID_HANDLE;
 
 //Menu Handlers
 new Handle:g_hSkillMenu = INVALID_HANDLE;
@@ -153,6 +155,7 @@ stock int b_attackerTarget[MAXPLAYERS+1];
 // Player Related Variables
 
 new LastClassConfirmed[MAXPLAYERS+1];
+new int g_iQueuedClass[MAXPLAYERS+1];
 new bool:g_bInSaferoom[MAXPLAYERS+1];
 new Float:g_SpawnPos[MAXPLAYERS+1][3];
 new bool:RoundStarted =false;

--- a/sourcemod/scripting/rage_survivor_guide.sp
+++ b/sourcemod/scripting/rage_survivor_guide.sp
@@ -1,6 +1,7 @@
 #define PLUGIN_VERSION "1.0"
 
 #include <sourcemod>
+#include <rage/skill_actions>
 
 #pragma semicolon 1
 #pragma newdecls required
@@ -20,6 +21,13 @@ public void OnPluginStart()
 
     CreateNative("RageGuide_ShowMainMenu", Native_ShowGuideMenu);
     RegPluginLibrary("rage_survivor_guide");
+
+    LoadSkillActionBindings();
+}
+
+public void OnConfigsExecuted()
+{
+    LoadSkillActionBindings();
 }
 
 public int Native_ShowGuideMenu(Handle plugin, int numParams)
@@ -54,6 +62,14 @@ void PrintGuideLine(int client, const char[] message)
     PrintToChat(client, "\x04[Rage]\x01 %s", message);
 }
 
+void GetBindingStrings(char[] action1, int len1, char[] action2, int len2, char[] action3, int len3, char[] deploy, int len4)
+{
+    GetSkillActionBindingLabel(SkillAction_Primary, action1, len1);
+    GetSkillActionBindingLabel(SkillAction_Secondary, action2, len2);
+    GetSkillActionBindingLabel(SkillAction_Tertiary, action3, len3);
+    GetSkillActionBindingLabel(SkillAction_Deploy, deploy, len4);
+}
+
 void DisplayGuideMainMenu(int client)
 {
     Menu menu = CreateMenu(MenuHandler_GuideMain);
@@ -79,7 +95,11 @@ public int MenuHandler_GuideMain(Menu menu, MenuAction action, int param1, int p
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Rage Edition is a modular class overhaul for Left 4 Dead 2 with perk-driven gameplay.");
-                PrintGuideLine(param1, "Every survivor picks a class with unique passives plus a !skill ability, so coordinate before leaving the saferoom.");
+                char action1[64], action2[64], action3[64], deploy[64];
+                char overviewLine[192];
+                GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
+                Format(overviewLine, sizeof(overviewLine), "Every survivor picks a class with unique passives plus abilities bound to %s, %s, and %s, so coordinate before leaving the saferoom.", action1, action2, action3);
+                PrintGuideLine(param1, overviewLine);
                 DisplayGuideMainMenu(param1);
             }
             else if (StrEqual(info, "classes"))
@@ -200,7 +220,11 @@ public int MenuHandler_Features(Menu menu, MenuAction action, int param1, int pa
             }
             else if (StrEqual(info, "skill"))
             {
-                PrintGuideLine(param1, "Bind !skill for class abilities and USE the deploy prompt to place turrets, shields and mines.");
+                char action1[64], action2[64], action3[64], deploy[64];
+                char skillLine[192];
+                GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
+                Format(skillLine, sizeof(skillLine), "Bind %s, %s and %s for class abilities and use %s to place turrets, shields and mines.", action1, action2, action3, deploy);
+                PrintGuideLine(param1, skillLine);
             }
             else if (StrEqual(info, "thirdperson"))
             {
@@ -251,13 +275,17 @@ public int MenuHandler_Soldier(Menu menu, MenuAction action, int param1, int par
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Soldiers run faster, shrug off damage and excel as the frontline tank for the squad.");
             }
             else if (StrEqual(info, "skill"))
             {
-                PrintGuideLine(param1, "Aim at a target and press !skill to call in the F-18 missile barrage. Give teammates a warning before painting.");
+                char skillLine[160];
+                Format(skillLine, sizeof(skillLine), "Aim at a target and press %s to call in the F-18 missile barrage. Give teammates a warning before painting.", action1);
+                PrintGuideLine(param1, skillLine);
             }
             else if (StrEqual(info, "utility"))
             {
@@ -357,17 +385,23 @@ public int MenuHandler_Commando(Menu menu, MenuAction action, int param1, int pa
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Commandos flex between rifles, shotguns and SMGs with baked-in damage bonuses for each slot.");
             }
             else if (StrEqual(info, "berserk"))
             {
-                PrintGuideLine(param1, "Build rage by dealing damage, then press !skill or !berserker to enter Berserk for huge speed and tank immunity.");
+                char berserkLine[192];
+                Format(berserkLine, sizeof(berserkLine), "Build rage by dealing damage, then press %s (or the berserker shortcut) to enter Berserk for huge speed and tank immunity.", action2);
+                PrintGuideLine(param1, berserkLine);
             }
             else if (StrEqual(info, "satellite"))
             {
-                PrintGuideLine(param1, "Use your class !skill for a satellite strike instead of the F-18 barrage. Call targets and clear the circle.");
+                char satelliteLine[192];
+                Format(satelliteLine, sizeof(satelliteLine), "Use %s for a satellite strike instead of the F-18 barrage. Call targets and clear the circle.", action1);
+                PrintGuideLine(param1, satelliteLine);
             }
             else if (StrEqual(info, "finishers"))
             {
@@ -410,17 +444,23 @@ public int MenuHandler_Medic(Menu menu, MenuAction action, int param1, int param
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Medics pulse heals to nearby survivors and thrive when glued to the front line.");
             }
             else if (StrEqual(info, "skill"))
             {
-                PrintGuideLine(param1, "Your class !skill boosts every heal—kits and pills restore more and you move faster while supporting.");
+                char boostLine[192];
+                Format(boostLine, sizeof(boostLine), "Your %s boosts every heal—kits and pills restore more and you move faster while supporting.", action1);
+                PrintGuideLine(param1, boostLine);
             }
             else if (StrEqual(info, "orbs"))
             {
-                PrintGuideLine(param1, "Use your secondary !skill to toss healing orbs that glow and ping the team. You can also drop med items for others.");
+                char orbLine[192];
+                Format(orbLine, sizeof(orbLine), "Use %s to toss healing orbs that glow and ping the team. You can also drop med items for others.", action2);
+                PrintGuideLine(param1, orbLine);
             }
             else if (StrEqual(info, "support"))
             {
@@ -463,17 +503,23 @@ public int MenuHandler_Engineer(Menu menu, MenuAction action, int param1, int pa
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Engineers fortify pushes with build kits, deployables and turrets that hold choke points.");
             }
             else if (StrEqual(info, "deploy"))
             {
-                PrintGuideLine(param1, "!skill opens the build wheel: choose deployable types, place them, then reclaim with USE when safe.");
+                char deployLine[192];
+                Format(deployLine, sizeof(deployLine), "%s opens the build wheel: choose deployable types, place them, then reclaim with USE when safe.", action1);
+                PrintGuideLine(param1, deployLine);
             }
             else if (StrEqual(info, "skill"))
             {
-                PrintGuideLine(param1, "Use !skill to open the turret menu, pick a gun and ammo, left-click to deploy and press USE to pick it up.");
+                char turretLine[192];
+                Format(turretLine, sizeof(turretLine), "Use %s to open the turret menu, pick a gun and ammo, left-click to deploy and press USE to pick it up.", action1);
+                PrintGuideLine(param1, turretLine);
             }
             else if (StrEqual(info, "defense"))
             {
@@ -517,13 +563,17 @@ public int MenuHandler_Saboteur(Menu menu, MenuAction action, int param1, int pa
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "overview"))
             {
                 PrintGuideLine(param1, "Saboteurs scout ahead with lower gun damage but brutal gadgets that control space.");
             }
             else if (StrEqual(info, "stealth"))
             {
-                PrintGuideLine(param1, "Use the Dead Ringer !skill (aliases !fd or !cloak) to vanish, drop a fake corpse and sprint past ambushes.");
+                char stealthLine[192];
+                Format(stealthLine, sizeof(stealthLine), "Use the Dead Ringer %s trigger to vanish, drop a fake corpse and sprint past ambushes.", action1);
+                PrintGuideLine(param1, stealthLine);
             }
             else if (StrEqual(info, "sight"))
             {
@@ -531,7 +581,9 @@ public int MenuHandler_Saboteur(Menu menu, MenuAction action, int param1, int pa
             }
             else if (StrEqual(info, "mines"))
             {
-                PrintGuideLine(param1, "Hold SHIFT to plant up to twenty mine types ranging from freeze traps to airstrikes. Mines glow to warn teammates.");
+                char minesLine[192];
+                Format(minesLine, sizeof(minesLine), "Use %s to plant up to twenty mine types ranging from freeze traps to airstrikes. Mines glow to warn teammates.", deploy);
+                PrintGuideLine(param1, minesLine);
             }
             else if (StrEqual(info, "tips"))
             {
@@ -580,13 +632,19 @@ public int MenuHandler_Skills(Menu menu, MenuAction action, int param1, int para
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "skill"))
             {
-                PrintGuideLine(param1, "Bind a key to !skill (or type the command) to trigger your class ability consistently every round.");
+                char bindLine[192];
+                Format(bindLine, sizeof(bindLine), "Bind keys to %s, %s and %s to trigger your class abilities consistently every round.", action1, action2, action3);
+                PrintGuideLine(param1, bindLine);
             }
             else if (StrEqual(info, "healingorb"))
             {
-                PrintGuideLine(param1, "Medics use their secondary !skill to throw a glowing healing orb from the main skills plugin. Toss it between fights to top the team off.");
+                char orbLine[192];
+                Format(orbLine, sizeof(orbLine), "Medics use %s to throw a glowing healing orb from the main skills plugin. Toss it between fights to top the team off.", action2);
+                PrintGuideLine(param1, orbLine);
             }
             else if (StrEqual(info, "deadringer"))
             {
@@ -598,7 +656,9 @@ public int MenuHandler_Skills(Menu menu, MenuAction action, int param1, int para
             }
             else if (StrEqual(info, "multiturret"))
             {
-                PrintGuideLine(param1, "Engineers open the turret picker with !skill, choose turret + ammo, left-click to place and USE to pick up.");
+                char turretLine[192];
+                Format(turretLine, sizeof(turretLine), "Engineers open the turret picker with %s, choose turret + ammo, left-click to place and USE to pick up.", action1);
+                PrintGuideLine(param1, turretLine);
             }
             else if (StrEqual(info, "music"))
             {
@@ -610,7 +670,9 @@ public int MenuHandler_Skills(Menu menu, MenuAction action, int param1, int para
             }
             else if (StrEqual(info, "berserk"))
             {
-                PrintGuideLine(param1, "Commandos hit !berserker or !skill once rage is full. Berserk grants burst damage and immunity to tank knockdowns.");
+                char berserkLine[192];
+                Format(berserkLine, sizeof(berserkLine), "Commandos hit !berserker or %s once rage is full. Berserk grants burst damage and immunity to tank knockdowns.", action2);
+                PrintGuideLine(param1, berserkLine);
             }
             else if (StrEqual(info, "satellite"))
             {
@@ -618,7 +680,9 @@ public int MenuHandler_Skills(Menu menu, MenuAction action, int param1, int para
             }
             else if (StrEqual(info, "airstrike"))
             {
-                PrintGuideLine(param1, "Soldiers aim and press !skill to mark a strike zone; warn teammates before raining missiles.");
+                char airstrikeLine[192];
+                Format(airstrikeLine, sizeof(airstrikeLine), "Soldiers aim and press %s to mark a strike zone; warn teammates before raining missiles.", action1);
+                PrintGuideLine(param1, airstrikeLine);
             }
             DisplaySkillMenu(param1);
         }
@@ -710,6 +774,8 @@ public int MenuHandler_Tips(Menu menu, MenuAction action, int param1, int param2
         {
             char info[32];
             GetMenuItem(menu, param2, info, sizeof(info));
+            char action1[64], action2[64], action3[64], deploy[64];
+            GetBindingStrings(action1, sizeof(action1), action2, sizeof(action2), action3, sizeof(action3), deploy, sizeof(deploy));
             if (StrEqual(info, "team"))
             {
                 PrintGuideLine(param1, "Mix roles - Soldier tanks, Medic heals, Engineer builds cover, Saboteur scouts and Athlete runs objectives.");
@@ -724,7 +790,9 @@ public int MenuHandler_Tips(Menu menu, MenuAction action, int param1, int param2
             }
             else if (StrEqual(info, "shortcuts"))
             {
-                PrintGuideLine(param1, "Bind !skill, !music, !unvomit, !extendedsight and !ragetutorial for instant access mid-fight.");
+                char shortcutLine[192];
+                Format(shortcutLine, sizeof(shortcutLine), "Bind %s, %s and %s alongside music, unvomit, extended sight and tutorial shortcuts for instant access mid-fight.", action1, action2, action3);
+                PrintGuideLine(param1, shortcutLine);
             }
             DisplayTipsMenu(param1);
         }

--- a/sourcemod/scripting/rage_survivor_menu.sp
+++ b/sourcemod/scripting/rage_survivor_menu.sp
@@ -449,6 +449,8 @@ public void RageMenu_OnSelect(int client, int menu_id, int option, int value)
             }
             case Menu_ChangeClass:
             {
+                PrintHintText(client, "Opening class picker with !class. Locked classes change next round.");
+                PrintToChat(client, "[Rage] Use the menu to pick a class. If you're already set, the new choice applies next round.");
                 ClientCommand(client, "sm_class");
             }
             case Menu_ViewRank:

--- a/sourcemod/scripting/rage_survivor_plugin_multiturret.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_multiturret.sp
@@ -6,6 +6,7 @@
 #include <sdktools_functions>
 #include <sdkhooks>
 #include <rage/skills>
+#include <rage/skill_actions>
 #define PLUGIN_NAME "[Rage Plugin] Portable turret & gatling guns."
 #define PLUGIN_VERSION "4.5"
 
@@ -357,7 +358,9 @@ public void OnSkillSelected(int iClient, int iClass)
     GetPlayerSkillName(iClient, szSkillName, sizeof(szSkillName));
     if (StrEqual(szSkillName, PLUGIN_SKILL_NAME))
     {
-        CustomPrintToChat(iClient, "%s %t", sPluginTag, "Skill Hint");
+        char primaryBind[64];
+        GetSkillActionBindingLabel(SkillAction_Primary, primaryBind, sizeof(primaryBind));
+        CustomPrintToChat(iClient, "%s %t", sPluginTag, "Skill Hint", primaryBind);
     }
 }
 
@@ -462,6 +465,8 @@ public void OnPluginStart()
 		SetFailState("Could not prep the 'CTerrorPlayer::OnStaggered' function.");
 	
 	LoadPluginTranslations();
+	
+	LoadSkillActionBindings();
 	
 	hCvar_MPGameMode 				= FindConVar("mp_gamemode");
 	hCvar_Machine_Enabled 			= CreateConVar("l4d_machine_enable", 				"1", 		"Enables/Disables the plugin. 0 = Plugin OFF, 1 = Plugin ON.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
@@ -4737,4 +4742,9 @@ stock void RemoveColorCodes(char[] sText, int iMaxLength)
 	ReplaceString(sText, iMaxLength, "'Blue'", "");
 	ReplaceString(sText, iMaxLength, "'Red'", "");
 	ReplaceString(sText, iMaxLength, "'White'", "");
+}
+
+public void OnConfigsExecuted()
+{
+	LoadSkillActionBindings();
 }

--- a/sourcemod/translations/rage_multiturret.phrases.txt
+++ b/sourcemod/translations/rage_multiturret.phrases.txt
@@ -90,7 +90,7 @@
 	}
 	"Skill Hint"
 	{
-		"en"		"Press the class skill key (default middle mouse or type !skill) to open the turret menu."
+		"en"		"Press %s to open the turret menu."
 	}
 	"Reload Machine Gun"
 	{


### PR DESCRIPTION
## Summary
- add a shared skill action binding helper and config so servers can map skill_action placeholders to real button prompts
- update the survivor core, tutorial guide, and turret hinting to use the configured bindings and include the tertiary class skill slot
- document the default bindings and where to adjust them for server-specific layouts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692361a86df08326859daf7adc3b929c)