### PR TITLE
Define parachute model defaults

### DIFF
--- a/sourcemod/scripting/include/rage/movement.inc
+++ b/sourcemod/scripting/include/rage/movement.inc
@@ -3,6 +3,14 @@
 #endif
 #define _rage_movement_included
 
+#if !defined PARACHUTE
+    #define PARACHUTE "models/props_swamp/parachute01.mdl"
+#endif
+
+#if !defined FAN_BLADE
+    #define FAN_BLADE "models/props/de_inferno/ceiling_fan_blade.mdl"
+#endif
+
 #if !defined SOUND_HELICOPTER
     #define SOUND_HELICOPTER "vehicles/airboat/fan_blade_fullthrottle_loop1.wav"
 #endif


### PR DESCRIPTION
## Summary
- add default model definitions for parachute and fan blade when not provided to avoid missing symbol errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229342acb88326a833a704a45e9669)