### PR TITLE
Refactor class command handlers into separate include

### DIFF
--- a/sourcemod/scripting/include/rage/admin_commands.inc
+++ b/sourcemod/scripting/include/rage/admin_commands.inc
@@ -1,0 +1,40 @@
+#if defined _RAGE_ADMIN_COMMANDS_INC
+        #endinput
+#endif
+#define _RAGE_ADMIN_COMMANDS_INC
+
+#include <sourcemod>
+
+forward Action CmdRageMenu(int client, int args);
+forward Action Cmd_PrintToHUD(int client, int args);
+forward Action Cmd_ClearHUD(int client, int args);
+forward Action Cmd_DeleteHUD(int client, int args);
+forward Action Cmd_CloseHUD(int client, int args);
+forward Action Cmd_GetHud(int client, int args);
+forward Action Cmd_SetHud(int client, int args);
+forward Action Cmd_SetupHud(int client, int args);
+forward Action Cmd_SetVictim(int client, int args);
+forward Action Command_Debug(int client, int args);
+forward Action CmdModel(int client, int args);
+forward Action CmdPlugins(int client, int args);
+forward Action GrenadeCommand(int client, int args);
+forward Action HideCommand(int client, int args);
+
+stock void RegisterAdminCommands()
+{
+        RegAdminCmd("sm_ragem", CmdRageMenu, ADMFLAG_ROOT, "Debug & Manage");
+        RegAdminCmd("sm_hide", HideCommand, ADMFLAG_ROOT, "Hide player");
+        RegAdminCmd("sm_rage_plugins", CmdPlugins, ADMFLAG_ROOT, "List plugins");
+        RegAdminCmd("sm_yay", GrenadeCommand, ADMFLAG_ROOT, "Test grenades");
+        RegAdminCmd("sm_hud", Cmd_PrintToHUD, ADMFLAG_ROOT, "Test HUD");
+        RegAdminCmd("sm_hud_clear", Cmd_ClearHUD, ADMFLAG_ROOT, "Clear HUD");
+        RegAdminCmd("sm_hud_delete", Cmd_DeleteHUD, ADMFLAG_ROOT, "Delete HUD");
+        RegAdminCmd("sm_hud_close", Cmd_CloseHUD, ADMFLAG_ROOT, "Delete HUD");
+        RegAdminCmd("sm_hud_get", Cmd_GetHud, ADMFLAG_ROOT, "Delete HUD");
+        RegAdminCmd("sm_hud_set", Cmd_SetHud, ADMFLAG_ROOT, "Delete HUD");
+        RegAdminCmd("sm_hud_setup", Cmd_SetupHud, ADMFLAG_ROOT, "Delete HUD");
+        RegAdminCmd("sm_setvictim", Cmd_SetVictim, ADMFLAG_ROOT, "Set horde to attack player #");
+        RegAdminCmd("sm_debug", Command_Debug, ADMFLAG_GENERIC, "sm_debug [0 = Off|1 = PrintToChat|2 = LogToFile|3 = PrintToChat AND LogToFile]");
+        RegAdminCmd("sm_model", CmdModel, ADMFLAG_GENERIC, "Change model to custom one");
+}
+

--- a/sourcemod/scripting/include/rage/class_commands.inc
+++ b/sourcemod/scripting/include/rage/class_commands.inc
@@ -1,0 +1,100 @@
+#if defined _RAGE_CLASS_COMMANDS_INC
+        #endinput
+#endif
+#define _RAGE_CLASS_COMMANDS_INC
+
+#include <sourcemod>
+
+forward bool ApplyClassSelection(int client, int classIndex);
+
+public Action CmdClassInfo(int client, int args)
+{
+        PrintToChat(client,"\x05Soldier\x01 = Has faster attack rate, runs faster and takes less damage");
+        PrintToChat(client,"\x05Athlete\x01 = Jumps higher, has parachute.");
+        PrintToChat(client,"\x05Medic\x01 = Heals others, plants medical supplies. Faster revive & heal speed");
+        PrintToChat(client,"\x05Saboteur\x01 = Can go invisible, plants powerful mines and throws special grenades");
+        PrintToChat(client,"\x05Commando\x01 = Has fast reload, deals extra damage");
+        PrintToChat(client,"\x05Engineer\x01 = Drops auto turrets and ammo");
+        PrintToChat(client,"\x05Brawler\x01 = Has Lots of health");
+
+        return Plugin_Handled;
+}
+
+public Action CmdClassMenu(int client, int args)
+{
+        if (GetClientTeam(client) != 2)
+        {
+                PrintToChat(client, "%sOnly Survivors can choose a class.", PRINT_PREFIX);
+                return Plugin_Handled;
+        }
+        CreatePlayerClassMenu(client);
+
+        return Plugin_Handled;
+}
+
+public Action CmdClassSet(int client, int args)
+{
+        if (GetClientTeam(client) != 2)
+        {
+                PrintToChat(client, "%sOnly Survivors can choose a class.", PRINT_PREFIX);
+                return Plugin_Handled;
+        }
+
+        if (args < 1)
+        {
+                PrintToChat(client, "%sSelect a class number between 1 and %d.", PRINT_PREFIX, view_as<int>(MAXCLASSES) - 1);
+                return Plugin_Handled;
+        }
+
+        char arg[16];
+        GetCmdArg(1, arg, sizeof(arg));
+
+        int classIndex = StringToInt(arg);
+        if (classIndex <= 0 || classIndex >= view_as<int>(MAXCLASSES))
+        {
+                PrintToChat(client, "%sSelect a class number between 1 and %d.", PRINT_PREFIX, view_as<int>(MAXCLASSES) - 1);
+                return Plugin_Handled;
+        }
+
+        ApplyClassSelection(client, classIndex);
+        return Plugin_Handled;
+}
+
+public Action CreatePlayerClassMenuDelay(Handle hTimer, any client)
+{
+        CreatePlayerClassMenu(client);
+
+        return Plugin_Stop;
+}
+
+stock Action CmdClasses(int client, int args)
+{
+        for (new i = 1; i <= MaxClients; i++)
+        {
+
+
+                if(IsClientInGame(i) && GetClientTeam(i) == 2 && ClientData[i].ChosenClass != NONE)
+                {
+                        static char translation[256];
+
+                        Format(translation, sizeof(translation), "\x04%N\x01 is a {green}%s{white}%s",i,MENU_OPTIONS[ClientData[i].ChosenClass], ClassTips[ClientData[i].ChosenClass]);
+                        ReplaceColors(translation, sizeof(translation));
+                        PrintToChatAll(translation);
+                }
+        }
+
+        return Plugin_Handled;
+}
+
+public Action CmdPlugins(int client, int args)
+{
+        for (new i = 1; i <= MaxClients; i++)
+        {
+                if(ClientData[i].ChosenClass != NONE)
+                {
+                        PrintToChat(client, "\x04%N\x01 is a %s",i,MENU_OPTIONS[ClientData[i].ChosenClass]);
+                }
+        }
+
+        return Plugin_Handled;
+}

--- a/sourcemod/scripting/include/rage/commands.inc
+++ b/sourcemod/scripting/include/rage/commands.inc
@@ -1,5 +1,8 @@
- 
- 
+#if defined _RAGE_COMMANDS_INC
+        #endinput
+#endif
+#define _RAGE_COMMANDS_INC
+
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>

--- a/sourcemod/scripting/include/rage/commands.inc
+++ b/sourcemod/scripting/include/rage/commands.inc
@@ -1,10 +1,8 @@
  
-
+ 
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
-
-stock bool ApplyClassSelection(int client, int classIndex);
 
 public Action Command_Debug(int client, int args) {
 	
@@ -23,17 +21,6 @@ public Action Command_Debug(int client, int args) {
 
 	return Plugin_Handled;
 }
-
-public Action CmdClassInfo(int client, int args)
-{
-	PrintToChat(client,"\x05Soldier\x01 = Has faster attack rate, runs faster and takes less damage");
-	PrintToChat(client,"\x05Athlete\x01 = Jumps higher, has parachute.");
-	PrintToChat(client,"\x05Medic\x01 = Heals others, plants medical supplies. Faster revive & heal speed");
-	PrintToChat(client,"\x05Saboteur\x01 = Can go invisible, plants powerful mines and throws special grenades");
-	PrintToChat(client,"\x05Commando\x01 = Has fast reload, deals extra damage");
-	PrintToChat(client,"\x05Engineer\x01 = Drops auto turrets and ammo");
-	PrintToChat(client,"\x05Brawler\x01 = Has Lots of health");	
-}
 public Action CmdModel(int client, int args) {
         if (args < 1)
         {
@@ -49,76 +36,6 @@ public Action CmdModel(int client, int args) {
 
         return Plugin_Handled;
 
-}
-public Action CmdClassMenu(int client, int args)
-{
-        if (GetClientTeam(client) != 2)
-        {
-                PrintToChat(client, "%sOnly Survivors can choose a class.", PRINT_PREFIX);
-                return;
-        }
-        CreatePlayerClassMenu(client);
-}
-
-public Action CmdClassSet(int client, int args)
-{
-        if (GetClientTeam(client) != 2)
-        {
-                PrintToChat(client, "%sOnly Survivors can choose a class.", PRINT_PREFIX);
-                return Plugin_Handled;
-        }
-
-        if (args < 1)
-        {
-                PrintToChat(client, "%sSelect a class number between 1 and %d.", PRINT_PREFIX, view_as<int>(MAXCLASSES) - 1);
-                return Plugin_Handled;
-        }
-
-        char arg[16];
-        GetCmdArg(1, arg, sizeof(arg));
-
-        int classIndex = StringToInt(arg);
-        if (classIndex <= 0 || classIndex >= view_as<int>(MAXCLASSES))
-        {
-                PrintToChat(client, "%sSelect a class number between 1 and %d.", PRINT_PREFIX, view_as<int>(MAXCLASSES) - 1);
-                return Plugin_Handled;
-        }
-
-        ApplyClassSelection(client, classIndex);
-        return Plugin_Handled;
-}
-
-public Action CreatePlayerClassMenuDelay(Handle hTimer, any client)
-{
-	CreatePlayerClassMenu(client);
-}
-
-stock Action CmdClasses(int client, int args)
-{	
-	for (new i = 1; i <= MaxClients; i++)
-	{
-
-
-		if(IsClientInGame(i) && GetClientTeam(i) == 2 && ClientData[i].ChosenClass != NONE)
-		{
-			static char translation[256];
-
-			Format(translation, sizeof(translation), "\x04%N\x01 is a {green}%s{white}%s",i,MENU_OPTIONS[ClientData[i].ChosenClass], ClassTips[ClientData[i].ChosenClass]);
-			ReplaceColors(translation, sizeof(translation));
-			PrintToChatAll(translation);
-		}
-	}
-}
-
-public Action CmdPlugins(int client, int args)
-{
-	for (new i = 1; i <= MaxClients; i++)
-	{
-		if(ClientData[i].ChosenClass != NONE)
-		{
-			PrintToChat(client, "\x04%N\x01 is a %s",i,MENU_OPTIONS[ClientData[i].ChosenClass]);
-		}
-	}
 }
 
 public Action Cmd_SetVictim(int client, int args) {

--- a/sourcemod/scripting/include/rage/menus.inc
+++ b/sourcemod/scripting/include/rage/menus.inc
@@ -54,13 +54,7 @@ public bool ApplyClassSelection(int client, int classIndex)
         }
 
         LastClassConfirmed[client] = classIndex;
-
-        if (g_hClassCookie != INVALID_HANDLE)
-        {
-                char classValue[8];
-                IntToString(classIndex, classValue, sizeof(classValue));
-                SetClientCookie(client, g_hClassCookie, classValue);
-        }
+        SaveClassCookie(client, view_as<ClassTypes>(classIndex));
 
         if (RoundStarted == true && hasActiveClass && view_as<int>(oldClass) != classIndex)
         {

--- a/sourcemod/scripting/include/rage/menus.inc
+++ b/sourcemod/scripting/include/rage/menus.inc
@@ -37,7 +37,7 @@ stock void ShowClassHud(int client, bool skillReady, const char[] readyText = ""
         }
 }
 
-stock bool ApplyClassSelection(int client, int classIndex)
+public bool ApplyClassSelection(int client, int classIndex)
 {
         if (client <= 0 || classIndex <= 0 || classIndex >= view_as<int>(MAXCLASSES) || GetClientTeam(client) != 2)
         {
@@ -568,7 +568,7 @@ public void Admin_TopMainMenu(TopMenu topmenu, TopMenuAction action, TopMenuObje
 	}
 }
 
-public void OnAdminMenuReady(TopMenu topmenu) {
+public void OnAdminMenuReady(Handle topmenu) {
 	
 	// Check ..
 	if (topmenu == hTopMenu) return;

--- a/sourcemod/scripting/include/rage/skill_actions.inc
+++ b/sourcemod/scripting/include/rage/skill_actions.inc
@@ -66,10 +66,11 @@ void LoadSkillActionBindings()
 void GetSkillActionBindingLabel(SkillActionSlot slot, char[] buffer, int maxlen)
 {
     buffer[0] = '\0';
-    if (slot < 0 || slot >= SkillActionSlot_Count)
+    int slotIndex = view_as<int>(slot);
+    if (slotIndex < 0 || slotIndex >= SkillActionSlot_Count)
     {
         return;
     }
 
-    strcopy(buffer, maxlen, g_SkillActionBindings[slot]);
+    strcopy(buffer, maxlen, g_SkillActionBindings[slotIndex]);
 }

--- a/sourcemod/scripting/include/talents.inc
+++ b/sourcemod/scripting/include/talents.inc
@@ -254,6 +254,8 @@ new Handle:SPECIAL_SKILL_LIMIT;
 #include <rage/effects>
 #include <rage/menus>
 #include <rage/perks>
+#include <rage/admin_commands>
 #include <rage/class_commands>
 #include <rage/commands>
+
 

--- a/sourcemod/scripting/include/talents.inc
+++ b/sourcemod/scripting/include/talents.inc
@@ -254,5 +254,6 @@ new Handle:SPECIAL_SKILL_LIMIT;
 #include <rage/effects>
 #include <rage/menus>
 #include <rage/perks>
+#include <rage/class_commands>
 #include <rage/commands>
 

--- a/sourcemod/scripting/rage_survivor.sp
+++ b/sourcemod/scripting/rage_survivor.sp
@@ -587,20 +587,7 @@ public OnPluginStart( )
         RegConsoleCmd("deployment_action", CmdDeploymentAction, "Trigger your deployment action (look down + SHIFT by default)");
         RegConsoleCmd("sm_skill", CmdUseSkill, "Use your class special skill");
         g_hClassCookie = RegClientCookie("rage_class_choice", "Rage preferred class", CookieAccess_Public);
-        RegAdminCmd("sm_ragem", CmdRageMenu, ADMFLAG_ROOT, "Debug & Manage");
-        RegAdminCmd("sm_hide", HideCommand, ADMFLAG_ROOT, "Hide player");
-        RegAdminCmd("sm_rage_plugins", CmdPlugins, ADMFLAG_ROOT, "List plugins");
-        RegAdminCmd("sm_yay", GrenadeCommand, ADMFLAG_ROOT, "Test grenades");
-	RegAdminCmd("sm_hud", Cmd_PrintToHUD, ADMFLAG_ROOT, "Test HUD");
-	RegAdminCmd("sm_hud_clear", Cmd_ClearHUD, ADMFLAG_ROOT, "Clear HUD");
-	RegAdminCmd("sm_hud_delete", Cmd_DeleteHUD, ADMFLAG_ROOT, "Delete HUD");
-	RegAdminCmd("sm_hud_close", Cmd_CloseHUD, ADMFLAG_ROOT, "Delete HUD");
-	RegAdminCmd("sm_hud_get", Cmd_GetHud, ADMFLAG_ROOT, "Delete HUD");
-	RegAdminCmd("sm_hud_set", Cmd_SetHud, ADMFLAG_ROOT, "Delete HUD");
-        RegAdminCmd("sm_hud_setup", Cmd_SetupHud, ADMFLAG_ROOT, "Delete HUD");
-        RegAdminCmd("sm_setvictim", Cmd_SetVictim, ADMFLAG_ROOT, "Set horde to attack player #");
-        RegAdminCmd("sm_debug", Command_Debug, ADMFLAG_GENERIC, "sm_debug [0 = Off|1 = PrintToChat|2 = LogToFile|3 = PrintToChat AND LogToFile]");
-        RegAdminCmd("sm_model", CmdModel, ADMFLAG_GENERIC, "Change model to custom one");
+        RegisterAdminCommands();
 
         // Api
 
@@ -1306,6 +1293,39 @@ public void OnClientCookiesCached(int client)
         g_iQueuedClass[client] = 0;
 
         PrintToChat(client, "%sRestored your %s class. Use the class menu to change it again.", PRINT_PREFIX, MENU_OPTIONS[storedClass]);
+        NotifySelectedClassHint(client);
+}
+
+void NotifySelectedClassHint(int client)
+{
+        if (client <= 0 || !IsClientInGame(client) || GetClientTeam(client) != 2)
+        {
+                return;
+        }
+
+        ClassTypes classType = ClientData[client].ChosenClass;
+
+        if (classType == NONE && LastClassConfirmed[client] != 0)
+        {
+                classType = view_as<ClassTypes>(LastClassConfirmed[client]);
+        }
+
+        if (classType == NONE)
+        {
+                return;
+        }
+
+        PrintHintText(client, "Class selected: %s", MENU_OPTIONS[classType]);
+}
+
+public Action TimerAnnounceSelectedClass(Handle timer, any data)
+{
+        for (int i = 1; i <= MaxClients; i++)
+        {
+                NotifySelectedClassHint(i);
+        }
+
+        return Plugin_Stop;
 }
 
 void DmgHookUnhook(bool enabled)
@@ -1538,10 +1558,11 @@ public Event_RoundChange(Handle:event, String:name[], bool:dontBroadcast)
 
 public Event_RoundStart(Handle:event, String:name[], bool:dontBroadcast)
 {
-	if( g_iPlayerSpawn == true && RoundStarted == true )
-		CreateTimer(1.0, TimerStart, _, TIMER_FLAG_NO_MAPCHANGE);
-	
-	RoundStarted = true;
+        if( g_iPlayerSpawn == true && RoundStarted == true )
+                CreateTimer(1.0, TimerStart, _, TIMER_FLAG_NO_MAPCHANGE);
+
+        RoundStarted = true;
+        CreateTimer(2.0, TimerAnnounceSelectedClass, _, TIMER_FLAG_NO_MAPCHANGE);
 }
 
 public void OnRoundState(int roundstate)
@@ -1647,6 +1668,7 @@ public Event_PlayerTeam(Handle:hEvent, String:sName[], bool:bDontBroadcast)
         {
                 ClientData[client].ChosenClass = view_as<ClassTypes>(LastClassConfirmed[client]);
                 PrintToChat(client, "\x01You are currently a \x04%s\x01. Mid-round changes apply next round.", MENU_OPTIONS[LastClassConfirmed[client]]);
+                NotifySelectedClassHint(client);
         }
 }
 

--- a/sourcemod/scripting/rage_survivor.sp
+++ b/sourcemod/scripting/rage_survivor.sp
@@ -602,8 +602,6 @@ public OnPluginStart( )
         RegAdminCmd("sm_debug", Command_Debug, ADMFLAG_GENERIC, "sm_debug [0 = Off|1 = PrintToChat|2 = LogToFile|3 = PrintToChat AND LogToFile]");
         RegAdminCmd("sm_model", CmdModel, ADMFLAG_GENERIC, "Change model to custom one");
 
-        g_hClassCookie = RegClientCookie("rage_last_class", "Last selected Rage class", CookieAccess_Protected);
-
         // Api
 
 	g_hfwdOnPlayerClassChange = CreateGlobalForward("OnPlayerClassChange", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
@@ -1310,33 +1308,9 @@ public void OnClientCookiesCached(int client)
         PrintToChat(client, "%sRestored your %s class. Use the class menu to change it again.", PRINT_PREFIX, MENU_OPTIONS[storedClass]);
 }
 
-public void OnClientCookiesCached(int client)
-{
-        if (g_hClassCookie == INVALID_HANDLE || !IsClientInGame(client) || IsFakeClient(client))
-        {
-                return;
-        }
-
-        char storedClass[8];
-        GetClientCookie(client, g_hClassCookie, storedClass, sizeof(storedClass));
-
-        int savedClass = StringToInt(storedClass);
-        if (savedClass > 0 && savedClass < view_as<int>(MAXCLASSES))
-        {
-                LastClassConfirmed[client] = savedClass;
-
-                if (ClientData[client].ChosenClass == NONE)
-                {
-                        ClientData[client].ChosenClass = view_as<ClassTypes>(savedClass);
-                }
-
-                PrintToChat(client, "%sLoaded your %s class. It will auto-apply on spawn; use the Rage menu to change anytime.", PRINT_PREFIX, MENU_OPTIONS[savedClass]);
-        }
-}
-
 void DmgHookUnhook(bool enabled)
 {
-	if( !enabled && g_bDmgHooked )
+        if( !enabled && g_bDmgHooked )
 	{
 		g_bDmgHooked = false;
 		for( int i = 1; i <= MaxClients; i++ )

--- a/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
@@ -30,13 +30,26 @@ new g_BeamSprite, g_HaloSprite, g_GlowSprite;
 
 new Float:HealingBallInterval[MAXPLAYERS+1], Float:HealingBallEffect[MAXPLAYERS+1],
         Float:HealingBallRadius[MAXPLAYERS+1], Float:HealingBallDuration[MAXPLAYERS+1];
+Handle g_hHealingOrbCooldown = INVALID_HANDLE;
+float g_fHealingOrbCooldown = 30.0;
+float g_fNextHealingOrbUse[MAXPLAYERS+1];
 
 public void OnPluginStart()
 {
+        g_hHealingOrbCooldown = CreateConVar("healing_orb_cooldown", "30.0", "Cooldown between healing orb uses in seconds.", CVAR_FLAGS, true, 0.0);
+        g_fHealingOrbCooldown = GetConVarFloat(g_hHealingOrbCooldown);
+        HookConVarChange(g_hHealingOrbCooldown, OnHealingOrbCooldownChanged);
+
         for (int i = 1; i <= MaxClients; ++i)
         {
                 HealingBallTimer[i] = INVALID_HANDLE;
+                g_fNextHealingOrbUse[i] = 0.0;
         }
+}
+
+public void OnHealingOrbCooldownChanged(Handle convar, const char[] oldValue, const char[] newValue)
+{
+        g_fHealingOrbCooldown = GetConVarFloat(convar);
 }
 
 public int OnSpecialSkillUsed(int client, int skill, int type)
@@ -45,11 +58,21 @@ public int OnSpecialSkillUsed(int client, int skill, int type)
         GetPlayerSkillName(client, skillName, sizeof(skillName));
         if(!StrEqual(skillName, PLUGIN_SKILL_NAME, false))
                 return 0;
-	
+
+        float now = GetEngineTime();
+        float remaining = g_fNextHealingOrbUse[client] - now;
+
+        if (remaining > 0.0)
+        {
+                PrintHintText(client, "Healing orb ready in %.0f seconds", remaining);
+                return 1;
+        }
+
         HealingBallInterval[client] = 1.0;
         HealingBallEffect[client] = 1.5;
         HealingBallRadius[client] = 130.0;
         HealingBallDuration[client] = 8.0;
+        g_fNextHealingOrbUse[client] = now + g_fHealingOrbCooldown;
         HealingBallFunction(client);
         PrintHintText(client, "Healing orb now active");
 
@@ -68,13 +91,25 @@ public void OnMapStart()
 
 public void OnMapEnd()
 {
-	for(new i = 1; i <= MaxClients; ++i)
-	{
-		if(HealingBallTimer[i] != INVALID_HANDLE)
-			KillTimer(HealingBallTimer[i]);
-		
-		HealingBallTimer[i] = INVALID_HANDLE;
-	}
+        for(new i = 1; i <= MaxClients; ++i)
+        {
+                if(HealingBallTimer[i] != INVALID_HANDLE)
+                        KillTimer(HealingBallTimer[i]);
+
+                HealingBallTimer[i] = INVALID_HANDLE;
+                g_fNextHealingOrbUse[i] = 0.0;
+        }
+}
+
+public void OnClientDisconnect(int client)
+{
+        if (HealingBallTimer[client] != INVALID_HANDLE)
+        {
+                KillTimer(HealingBallTimer[client]);
+                HealingBallTimer[client] = INVALID_HANDLE;
+        }
+
+        g_fNextHealingOrbUse[client] = 0.0;
 }
 
 public Action:HealingBallFunction(Client)

--- a/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
@@ -2,6 +2,7 @@
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
+#include <rage/skills>
 
 #define PLUGIN_VERSION	"0.2"
 #define CVAR_FLAGS		FCVAR_NONE
@@ -9,7 +10,7 @@
 #define PLUGIN_SKILL_DESCRIPTION "Summons a healing orb near the player to patch up allies."
 public Plugin myinfo =
 {
-	name = "[Rage] Healing orb skill",
+        name = "Healing orb skill",
 	author = "zonde306, Yani",
 	description = PLUGIN_SKILL_DESCRIPTION,
 	version = PLUGIN_VERSION,
@@ -38,17 +39,21 @@ public void OnPluginStart()
         }
 }
 
-public void OnSpecialSkillUsed(int client, const char[] skillName)
+public int OnSpecialSkillUsed(int client, int skill, int type)
 {
+        char skillName[32];
+        GetPlayerSkillName(client, skillName, sizeof(skillName));
         if(!StrEqual(skillName, PLUGIN_SKILL_NAME, false))
-                return;
+                return 0;
 	
-	HealingBallInterval[client] = 1.0;
-	HealingBallEffect[client] = 1.5;
-	HealingBallRadius[client] = 130.0;
-	HealingBallDuration[client] = 8.0;
-	HealingBallFunction(client);
-	PrintToChat(client, "\x03[Rage]\x01 Healing orb now active\x01", HealingBallDuration[client]);
+        HealingBallInterval[client] = 1.0;
+        HealingBallEffect[client] = 1.5;
+        HealingBallRadius[client] = 130.0;
+        HealingBallDuration[client] = 8.0;
+        HealingBallFunction(client);
+        PrintHintText(client, "Healing orb now active");
+
+        return 1;
 }
 
 public void OnMapStart()


### PR DESCRIPTION
## Summary
- move survivor class-related console command handlers into a new `class_commands` include for clearer organization
- update the shared talents include to pull the new class command definitions and keep the general commands include focused on admin and HUD utilities

## Testing
- ⚠️ Not run (spcomp compiler not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240c99f2d08326acfb07f87c0928d7)