### PR TITLE
Restore class hint callbacks for survivor plugin

### DIFF
--- a/sourcemod/scripting/rage_survivor.sp
+++ b/sourcemod/scripting/rage_survivor.sp
@@ -1583,11 +1583,41 @@ public Event_PlayerSpawn(Handle:hEvent, String:sName[], bool:bDontBroadcast)
                         else
                                 CreateTimer(1.0, CreatePlayerClassMenuDelay, client, TIMER_FLAG_NO_MAPCHANGE);
 
+                        CreateTimer(2.0, TimerAnnounceSelectedClass, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
                         ShowAthleteAbilityHint(client);
                 }
 
                 g_iPlayerSpawn = true;
         }
+}
+
+void NotifySelectedClassHint(int client)
+{
+        if (client <= 0 || client > MaxClients || !IsClientInGame(client) || GetClientTeam(client) != 2)
+        {
+                return;
+        }
+
+        ClassTypes classType = ClientData[client].ChosenClass;
+        if (classType == NONE)
+        {
+                PrintHintText(client, "Select a class from the Rage menu first.");
+                return;
+        }
+
+        PrintHintText(client, "You are playing as %s. Use your skill binds to activate abilities.", MENU_OPTIONS[classType]);
+}
+
+public Action TimerAnnounceSelectedClass(Handle timer, any userid)
+{
+        int client = GetClientOfUserId(userid);
+        if (client <= 0 || client > MaxClients)
+        {
+                return Plugin_Stop;
+        }
+
+        NotifySelectedClassHint(client);
+        return Plugin_Stop;
 }
 
 void ShowAthleteAbilityHint(int client)

--- a/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
+++ b/sourcemod/scripting/rage_survivor_plugin_healingorb.sp
@@ -42,10 +42,10 @@ public void OnPluginStart()
 public int OnSpecialSkillUsed(int client, int skill, int type)
 {
         char skillName[32];
-        GetPlayerSkillName(client, skillName, sizeof(skillName));
+        FindSkillNameById(skill, skillName, sizeof(skillName));
         if(!StrEqual(skillName, PLUGIN_SKILL_NAME, false))
                 return 0;
-	
+
         HealingBallInterval[client] = 1.0;
         HealingBallEffect[client] = 1.5;
         HealingBallRadius[client] = 130.0;


### PR DESCRIPTION
## Summary
- add a delayed announcement of the selected class when survivors spawn
- implement NotifySelectedClassHint and TimerAnnounceSelectedClass helpers to satisfy missing callbacks

## Testing
- not run (spcomp binary not executable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924115d59cc8326a37112a49be1caa4)