### PR TITLE
Include compiled plugins in artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,4 +77,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: l4d2_dlr-sm1.11.0-git6453-${{ matrix.os_short }}-${{ env.GITHUB_SHA_SHORT }}
-          path: package
+          path: |
+            package
+            sourcemod/plugins


### PR DESCRIPTION
## Summary
- update build workflow artifact upload to include compiled plugins under sourcemod/plugins

## Testing
- not run (CI only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242afb47c48326a1ccbe689b4a060a)