### PR TITLE
Fix HUD vertical wrapping using correct Y bounds

### DIFF
--- a/sourcemod/scripting/rage_survivor_hud.sp
+++ b/sourcemod/scripting/rage_survivor_hud.sp
@@ -1216,7 +1216,7 @@ void GetHUD_Pos()
                 g_fHUD3_Y -= g_fCvar_HUD3_Y_Speed;
 
                 if (g_fHUD3_Y < g_fCvar_HUD3_Y_Min)
-                    g_fHUD3_Y = g_fCvar_HUD3_X_Max;
+                    g_fHUD3_Y = g_fCvar_HUD3_Y_Max;
             }
         }
     }
@@ -1258,7 +1258,7 @@ void GetHUD_Pos()
                 g_fHUD4_Y -= g_fCvar_HUD4_Y_Speed;
 
                 if (g_fHUD4_Y < g_fCvar_HUD4_Y_Min)
-                    g_fHUD4_Y = g_fCvar_HUD4_X_Max;
+                    g_fHUD4_Y = g_fCvar_HUD4_Y_Max;
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix HUD3 and HUD4 vertical wrap logic to reset to their Y maximum instead of unrelated X maximum when moving upward

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e5998c0e08326aafdb1416bc683e1)