### PR TITLE
Integrate third-person support and clean rage menu

### DIFF
--- a/sourcemod/scripting/include/rage_menu_base.inc
+++ b/sourcemod/scripting/include/rage_menu_base.inc
@@ -43,6 +43,7 @@ public void __pl_rage_menu_base_SetNTVOptional()
         MarkNativeAsOptional("ExtraMenu_AddEntry");
         MarkNativeAsOptional("ExtraMenu_NewPage");
         MarkNativeAsOptional("ExtraMenu_Display");
+        MarkNativeAsOptional("ExtraMenu_SetClientValue");
 }
 #endif
 
@@ -124,6 +125,18 @@ native void ExtraMenu_NewPage(int menu_id);
 * @return	True on success, false otherwise (possibly if menu is not available).
 */
 native bool ExtraMenu_Display(int client, int menu_id, int time = MENU_TIME_FOREVER);
+
+/**
+* @brief Overrides the current value for a client and row in the menu.
+*
+* @param        menu_id                 The menu ID to modify, returned from ExtraMenu_Create()
+* @param        client                  Player whose row value should change
+* @param        row                     Row index to update
+* @param        value                   New value to store for the row
+*
+* @return       True on success, false otherwise.
+*/
+native bool ExtraMenu_SetClientValue(int menu_id, int client, int row, int value);
 
 /**
 * @brief Closes a menu for a client.

--- a/sourcemod/scripting/rage_menu_base.sp
+++ b/sourcemod/scripting/rage_menu_base.sp
@@ -579,28 +579,24 @@ int Native_SetClientValue(Handle plugin, int numParams)
         IntToString(menu_id, sKey, sizeof(sKey));
 
 #if VERIFY_INDEXES
-        if( g_AllMenus.ContainsKey(sKey) )
-#endif
+        if( !g_AllMenus.ContainsKey(sKey) )
         {
-                MenuData data;
-                g_AllMenus.GetArray(sKey, data, sizeof(data));
+                return false;
+        }
+#endif
 
-                int length = data.RowsData.Length;
-                if( row < 0 || row >= length )
-                {
-                        return false;
-                }
+        MenuData data;
+        g_AllMenus.GetArray(sKey, data, sizeof(data));
 
-                data.MenuVals[client].Set(row, value);
-                g_AllMenus.SetArray(sKey, data, sizeof(data));
-                return true;
+        int length = data.RowsData.Length;
+        if( row < 0 || row >= length )
+        {
+                return false;
         }
 
-#if VERIFY_INDEXES
-        return false;
-#endif
-
-        return false;
+        data.MenuVals[client].Set(row, value);
+        g_AllMenus.SetArray(sKey, data, sizeof(data));
+        return true;
 }
 
 int Native_CloseMenu(Handle plugin, int numParams)

--- a/sourcemod/scripting/rage_menu_base.sp
+++ b/sourcemod/scripting/rage_menu_base.sp
@@ -231,6 +231,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("ExtraMenu_AddOptions",	Native_AddOptions);
 	CreateNative("ExtraMenu_NewPage",		Native_AddPage);
 	CreateNative("ExtraMenu_Display",		Native_Display);
+	CreateNative("ExtraMenu_SetClientValue",	Native_SetClientValue);
 	CreateNative("ExtraMenu_Close",			Native_CloseMenu);
 
 	// Forward
@@ -561,8 +562,45 @@ int Native_Display(Handle plugin, int numParams)
 	}
 
 	#if VERIFY_INDEXES
-	return false;
-	#endif
+        return false;
+#endif
+}
+
+int Native_SetClientValue(Handle plugin, int numParams)
+{
+        int menu_id = GetNativeCell(1);
+        int client = GetNativeCell(2);
+        int row = GetNativeCell(3);
+        int value = GetNativeCell(4);
+
+        if( client <= 0 || client > MaxClients ) return false;
+
+        char sKey[MAX_KEYS];
+        IntToString(menu_id, sKey, sizeof(sKey));
+
+#if VERIFY_INDEXES
+        if( g_AllMenus.ContainsKey(sKey) )
+#endif
+        {
+                MenuData data;
+                g_AllMenus.GetArray(sKey, data, sizeof(data));
+
+                int length = data.RowsData.Length;
+                if( row < 0 || row >= length )
+                {
+                        return false;
+                }
+
+                data.MenuVals[client].Set(row, value);
+                g_AllMenus.SetArray(sKey, data, sizeof(data));
+                return true;
+        }
+
+#if VERIFY_INDEXES
+        return false;
+#endif
+
+        return false;
 }
 
 int Native_CloseMenu(Handle plugin, int numParams)

--- a/sourcemod/scripting/rage_survivor.sp
+++ b/sourcemod/scripting/rage_survivor.sp
@@ -1639,9 +1639,10 @@ public Action CmdDeploymentAction(int client, int args)
         if (g_ClassActionMode[classType][ClassSkill_Deploy] == ActionMode_None)
         {
                 char className[32] = "your class";
-                if (classType >= 0 && classType < MAXCLASSES)
+                int classIndex = view_as<int>(classType);
+                if (classIndex >= 0 && classIndex < MAXCLASSES)
                 {
-                        strcopy(className, sizeof(className), MENU_OPTIONS[classType]);
+                        strcopy(className, sizeof(className), MENU_OPTIONS[classIndex]);
                 }
                 PrintHintText(client, "No deployment action is bound for %s.", className);
                 return Plugin_Handled;

--- a/sourcemod/scripting/rage_survivor_menu.sp
+++ b/sourcemod/scripting/rage_survivor_menu.sp
@@ -569,199 +569,193 @@ public void RageMenu_OnSelect(int client, int menu_id, int option, int value)
         return;
     }
 
-    switch (menuOption)
+    if (menuOption == Menu_GetKit)
     {
-        case Menu_GetKit:
+        int maxKits = (g_hKitSlots != null) ? g_hKitSlots.IntValue : 1;
+        if (maxKits <= 0 || g_iKitsUsed[client] >= maxKits)
         {
-            int maxKits = (g_hKitSlots != null) ? g_hKitSlots.IntValue : 1;
-            if (maxKits <= 0 || g_iKitsUsed[client] >= maxKits)
-            {
-                PrintHintText(client, "out of kits");
-                return;
-            }
+            PrintHintText(client, "out of kits");
+            return;
+        }
 
-            g_iKitsUsed[client]++;
-            FakeClientCommand(client, "sm_kit");
+        g_iKitsUsed[client]++;
+        FakeClientCommand(client, "sm_kit");
 
-            int kitsRemaining = maxKits - g_iKitsUsed[client];
-            if (kitsRemaining < 0)
-            {
-                kitsRemaining = 0;
-            }
+        int kitsRemaining = maxKits - g_iKitsUsed[client];
+        if (kitsRemaining < 0)
+        {
+            kitsRemaining = 0;
+        }
 
-            PrintHintText(client, "Kit delivered (%d remaining).", kitsRemaining);
-            break;
-        }
-        case Menu_SetAway:
-        {
-            PrintHintText(client, "Away mode is not available here.");
-            break;
-        }
-        case Menu_SelectTeam:
-        {
-            PrintHintText(client, "Team selection is not available in this menu.");
-            break;
-        }
-        case Menu_ChangeClass:
-        {
-            if (value < 0 || value >= CLASS_OPTION_COUNT)
-            {
-                PrintHintText(client, "Choose a class with left/right to apply it.");
-                return;
-            }
-
-            int classIndex = value + 1; // class options skip the NONE slot
-            FakeClientCommand(client, "sm_class_set %d", classIndex);
-            PrintHintText(client, "Switching to %s", g_sClassOptions[value]);
-            break;
-        }
-        case Menu_DeployAction:
-        {
-            FakeClientCommand(client, "deployment_action");
-            break;
-        }
-        case Menu_ViewRank:
-        {
-            FakeClientCommand(client, "sm_stats");
-            break;
-        }
-        case Menu_VoteCustomMap:
-        {
-            PrintHintText(client, "Custom map voting is not configured.");
-            break;
-        }
-        case Menu_VoteGameMode:
-        {
-            ChangeGameModeByIndex(client, value);
-            break;
-        }
-        case Menu_ThirdPerson:
-        {
-            if (value < 0 || value > 2)
-            {
-                PrintHintText(client, "Invalid camera selection.");
-                return;
-            }
-
-            ThirdPersonMode newMode = view_as<ThirdPersonMode>(value);
-            g_ThirdPersonMode[client] = newMode;
-            PersistThirdPersonMode(client);
-            ApplyThirdPersonMode(client);
-            PrintHintText(client, "Camera mode set to %s.", (newMode == TP_Always) ? "Always" : (newMode == TP_MeleeOnly) ? "Melee only" : "Off");
-            break;
-        }
-        case Menu_MultiEquip:
-        {
-            PrintHintText(client, "Multiple equipment mode is not configured.");
-            break;
-        }
-        case Menu_HudToggle:
-        {
-            bool enableHud = value != 0;
-            SetHudEnabled(enableHud, client);
-            break;
-        }
-        case Menu_MusicToggle:
-        {
-            if (value == 0)
-            {
-                FakeClientCommand(client, "sm_music_pause");
-                PrintHintText(client, "Music paused.");
-            }
-            else
-            {
-                FakeClientCommand(client, "sm_music_play");
-                FakeClientCommand(client, "sm_music"); // open menu for quick control
-                PrintHintText(client, "Music playing. Use menu to change track.");
-            }
-            break;
-        }
-        case Menu_MusicVolume:
-        {
-            // Value from ExtraMenu list index (0-10). Clamp defensively.
-            int vol = value;
-            if (vol < 0)
-            {
-                vol = 0;
-            }
-            else if (vol > 10)
-            {
-                vol = 10;
-            }
-
-            FakeClientCommand(client, "sm_music_volume %d", vol);
-            PrintHintText(client, "Music volume set to %d%%", vol * 10);
-            break;
-        }
-        case Menu_SpawnItems:
-        {
-            PrintHintText(client, "Item spawning is not available.");
-            break;
-        }
-        case Menu_Reload:
-        {
-            PrintHintText(client, "Reload options are not available.");
-            break;
-        }
-        case Menu_ManageSkills:
-        {
-            PrintHintText(client, "Manage skills menu is not available.");
-            break;
-        }
-        case Menu_ManagePerks:
-        {
-            PrintHintText(client, "Perk management is not available.");
-            break;
-        }
-        case Menu_ApplyEffect:
-        {
-            PrintHintText(client, "Apply-effect option is not available.");
-            break;
-        }
-        case Menu_DebugMode:
-        {
-            PrintHintText(client, "Debug mode toggle is not wired here.");
-            break;
-        }
-        case Menu_HaltGame:
-        {
-            PrintHintText(client, "Halt game is not available.");
-            break;
-        }
-        case Menu_InfectedSpawn:
-        {
-            PrintHintText(client, "Infected spawn toggle is not available.");
-            break;
-        }
-        case Menu_GodMode:
-        {
-            PrintHintText(client, "God mode toggle is not available.");
-            break;
-        }
-        case Menu_RemoveWeapons:
-        {
-            PrintHintText(client, "Remove weapons option is not available.");
-            break;
-        }
-        case Menu_GameSpeed:
-        {
-            PrintHintText(client, "Game speed control is not available.");
-            break;
-        }
-        case Menu_Guide:
-        {
-            if (!TryShowGuideMenu(client))
-            {
-                PrintToChat(client, "[Rage] Tutorial plugin is not available right now.");
-            }
-            break;
-        }
-        default:
-        {
-            PrintHintText(client, "This menu option is not configured.");
-            break;
-        }
+        PrintHintText(client, "Kit delivered (%d remaining).", kitsRemaining);
+        return;
     }
+    else if (menuOption == Menu_SetAway)
+    {
+        PrintHintText(client, "Away mode is not available here.");
+        return;
+    }
+    else if (menuOption == Menu_SelectTeam)
+    {
+        PrintHintText(client, "Team selection is not available in this menu.");
+        return;
+    }
+    else if (menuOption == Menu_ChangeClass)
+    {
+        if (value < 0 || value >= CLASS_OPTION_COUNT)
+        {
+            PrintHintText(client, "Choose a class with left/right to apply it.");
+            return;
+        }
+
+        int classIndex = value + 1; // class options skip the NONE slot
+        FakeClientCommand(client, "sm_class_set %d", classIndex);
+        PrintHintText(client, "Switching to %s", g_sClassOptions[value]);
+        return;
+    }
+    else if (menuOption == Menu_DeployAction)
+    {
+        FakeClientCommand(client, "deployment_action");
+        return;
+    }
+    else if (menuOption == Menu_ViewRank)
+    {
+        FakeClientCommand(client, "sm_stats");
+        return;
+    }
+    else if (menuOption == Menu_VoteCustomMap)
+    {
+        PrintHintText(client, "Custom map voting is not configured.");
+        return;
+    }
+    else if (menuOption == Menu_VoteGameMode)
+    {
+        ChangeGameModeByIndex(client, value);
+        return;
+    }
+    else if (menuOption == Menu_ThirdPerson)
+    {
+        if (value < 0 || value > 2)
+        {
+            PrintHintText(client, "Invalid camera selection.");
+            return;
+        }
+
+        ThirdPersonMode newMode = view_as<ThirdPersonMode>(value);
+        g_ThirdPersonMode[client] = newMode;
+        PersistThirdPersonMode(client);
+        ApplyThirdPersonMode(client);
+        PrintHintText(client, "Camera mode set to %s.", (newMode == TP_Always) ? "Always" : (newMode == TP_MeleeOnly) ? "Melee only" : "Off");
+        return;
+    }
+    else if (menuOption == Menu_MultiEquip)
+    {
+        PrintHintText(client, "Multiple equipment mode is not configured.");
+        return;
+    }
+    else if (menuOption == Menu_HudToggle)
+    {
+        bool enableHud = value != 0;
+        SetHudEnabled(enableHud, client);
+        return;
+    }
+    else if (menuOption == Menu_MusicToggle)
+    {
+        if (value == 0)
+        {
+            FakeClientCommand(client, "sm_music_pause");
+            PrintHintText(client, "Music paused.");
+        }
+        else
+        {
+            FakeClientCommand(client, "sm_music_play");
+            FakeClientCommand(client, "sm_music"); // open menu for quick control
+            PrintHintText(client, "Music playing. Use menu to change track.");
+        }
+        return;
+    }
+    else if (menuOption == Menu_MusicVolume)
+    {
+        // Value from ExtraMenu list index (0-10). Clamp defensively.
+        int vol = value;
+        if (vol < 0)
+        {
+            vol = 0;
+        }
+        else if (vol > 10)
+        {
+            vol = 10;
+        }
+
+        FakeClientCommand(client, "sm_music_volume %d", vol);
+        PrintHintText(client, "Music volume set to %d%%", vol * 10);
+        return;
+    }
+    else if (menuOption == Menu_SpawnItems)
+    {
+        PrintHintText(client, "Item spawning is not available.");
+        return;
+    }
+    else if (menuOption == Menu_Reload)
+    {
+        PrintHintText(client, "Reload options are not available.");
+        return;
+    }
+    else if (menuOption == Menu_ManageSkills)
+    {
+        PrintHintText(client, "Manage skills menu is not available.");
+        return;
+    }
+    else if (menuOption == Menu_ManagePerks)
+    {
+        PrintHintText(client, "Perk management is not available.");
+        return;
+    }
+    else if (menuOption == Menu_ApplyEffect)
+    {
+        PrintHintText(client, "Apply-effect option is not available.");
+        return;
+    }
+    else if (menuOption == Menu_DebugMode)
+    {
+        PrintHintText(client, "Debug mode toggle is not wired here.");
+        return;
+    }
+    else if (menuOption == Menu_HaltGame)
+    {
+        PrintHintText(client, "Halt game is not available.");
+        return;
+    }
+    else if (menuOption == Menu_InfectedSpawn)
+    {
+        PrintHintText(client, "Infected spawn toggle is not available.");
+        return;
+    }
+    else if (menuOption == Menu_GodMode)
+    {
+        PrintHintText(client, "God mode toggle is not available.");
+        return;
+    }
+    else if (menuOption == Menu_RemoveWeapons)
+    {
+        PrintHintText(client, "Remove weapons option is not available.");
+        return;
+    }
+    else if (menuOption == Menu_GameSpeed)
+    {
+        PrintHintText(client, "Game speed control is not available.");
+        return;
+    }
+    else if (menuOption == Menu_Guide)
+    {
+        if (!TryShowGuideMenu(client))
+        {
+            PrintToChat(client, "[Rage] Tutorial plugin is not available right now.");
+        }
+        return;
+    }
+
+    PrintHintText(client, "This menu option is not configured.");
 
 }
 

--- a/sourcemod/scripting/rage_survivor_thirdperson.sp
+++ b/sourcemod/scripting/rage_survivor_thirdperson.sp
@@ -1,0 +1,372 @@
+/**
+ * Survivor Thirdperson (integrated for Rage menu support)
+ * Original author: SilverShot
+ */
+
+#define PLUGIN_VERSION "1.9"
+
+#pragma semicolon 1
+#pragma newdecls required
+
+#include <sourcemod>
+#include <sdktools>
+#include <sdkhooks>
+
+#define CVAR_FLAGS          FCVAR_NOTIFY
+#define CHAT_TAG            "\x04[\x05Thirdperson\x04] \x01"
+
+ConVar g_hCvarAllow, g_hCvarMPGameMode, g_hCvarModes, g_hCvarModesOff, g_hCvarModesTog;
+bool g_bCvarAllow, g_bMapStarted, g_bThirdView[MAXPLAYERS+1], g_bMountedGun[MAXPLAYERS+1];
+Handle g_hTimerReset[MAXPLAYERS+1], g_hTimerGun;
+
+public Plugin myinfo =
+{
+    name = "[L4D2] Survivor Thirdperson",
+    author = "SilverShot",
+    description = "Creates a command for survivors to use thirdperson view.",
+    version = PLUGIN_VERSION,
+    url = "https://forums.alliedmods.net/showthread.php?t=185664"
+};
+
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
+    EngineVersion test = GetEngineVersion();
+    if (test != Engine_Left4Dead2)
+    {
+        strcopy(error, err_max, "Plugin only supports Left 4 Dead 2.");
+        return APLRes_SilentFailure;
+    }
+    return APLRes_Success;
+}
+
+public void OnPluginStart()
+{
+    LoadTranslations("common.phrases");
+
+    g_hCvarAllow = CreateConVar("l4d2_third_allow", "1", "0=Plugin off, 1=Plugin on.", CVAR_FLAGS);
+    g_hCvarModes = CreateConVar("l4d2_third_modes", "", "Turn on the plugin in these game modes, separate by commas (no spaces). (Empty = all).", CVAR_FLAGS);
+    g_hCvarModesOff = CreateConVar("l4d2_third_modes_off", "", "Turn off the plugin in these game modes, separate by commas (no spaces). (Empty = none).", CVAR_FLAGS);
+    g_hCvarModesTog = CreateConVar("l4d2_third_modes_tog", "0", "Turn on the plugin in these game modes. 0=All, 1=Coop, 2=Survival, 4=Versus, 8=Scavenge. Add numbers together.", CVAR_FLAGS);
+    CreateConVar("l4d2_third_version", PLUGIN_VERSION, "Survivor Thirdperson plugin version.", FCVAR_NOTIFY|FCVAR_DONTRECORD);
+    AutoExecConfig(true, "l4d2_third");
+
+    RegConsoleCmd("sm_3rdoff", CmdTP_Off, "Turns thirdperson view off.");
+    RegConsoleCmd("sm_3rdon", CmdTP_On, "Turns thirdperson view on.");
+    RegConsoleCmd("sm_3rd", CmdThird, "Toggles thirdperson view.");
+    RegConsoleCmd("sm_tp", CmdThird, "Toggles thirdperson view.");
+    RegConsoleCmd("sm_third", CmdThird, "Toggles thirdperson view.");
+
+    g_hCvarMPGameMode = FindConVar("mp_gamemode");
+    g_hCvarMPGameMode.AddChangeHook(ConVarChanged_Allow);
+    g_hCvarAllow.AddChangeHook(ConVarChanged_Allow);
+    g_hCvarModes.AddChangeHook(ConVarChanged_Allow);
+    g_hCvarModesOff.AddChangeHook(ConVarChanged_Allow);
+    g_hCvarModesTog.AddChangeHook(ConVarChanged_Allow);
+}
+
+public void OnPluginEnd()
+{
+    ResetPlugin();
+}
+
+public void OnMapStart()
+{
+    g_bMapStarted = true;
+}
+
+public void OnMapEnd()
+{
+    g_bMapStarted = false;
+    ResetPlugin();
+}
+
+void ResetPlugin()
+{
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        if (IsClientInGame(i) && IsPlayerAlive(i))
+        {
+            g_bMountedGun[i] = false;
+            g_bThirdView[i] = false;
+            SetEntPropFloat(i, Prop_Send, "m_TimeForceExternalView", 0.0);
+        }
+    }
+}
+
+public void OnConfigsExecuted()
+{
+    IsAllowed();
+}
+
+void ConVarChanged_Allow(Handle convar, const char[] oldValue, const char[] newValue)
+{
+    IsAllowed();
+}
+
+int g_iCurrentMode;
+bool IsAllowedGameMode()
+{
+    if (g_hCvarMPGameMode == null)
+        return false;
+
+    int iCvarModesTog = g_hCvarModesTog.IntValue;
+    if (iCvarModesTog != 0)
+    {
+        if (g_bMapStarted == false)
+            return false;
+
+        g_iCurrentMode = 0;
+
+        int entity = CreateEntityByName("info_gamemode");
+        if (IsValidEntity(entity))
+        {
+            DispatchSpawn(entity);
+            HookSingleEntityOutput(entity, "OnCoop", OnGamemode, true);
+            HookSingleEntityOutput(entity, "OnSurvival", OnGamemode, true);
+            HookSingleEntityOutput(entity, "OnVersus", OnGamemode, true);
+            HookSingleEntityOutput(entity, "OnScavenge", OnGamemode, true);
+            ActivateEntity(entity);
+            AcceptEntityInput(entity, "PostSpawnActivate");
+            if (IsValidEntity(entity))
+                RemoveEdict(entity);
+        }
+
+        if (g_iCurrentMode == 0)
+            return false;
+
+        if (!(iCvarModesTog & g_iCurrentMode))
+            return false;
+    }
+
+    char sGameModes[64], sGameMode[64];
+    g_hCvarMPGameMode.GetString(sGameMode, sizeof(sGameMode));
+    Format(sGameMode, sizeof(sGameMode), ",%s,", sGameMode);
+
+    g_hCvarModes.GetString(sGameModes, sizeof(sGameModes));
+    if (sGameModes[0])
+    {
+        Format(sGameModes, sizeof(sGameModes), ",%s,", sGameModes);
+        if (StrContains(sGameModes, sGameMode, false) == -1)
+            return false;
+    }
+
+    g_hCvarModesOff.GetString(sGameModes, sizeof(sGameModes));
+    if (sGameModes[0])
+    {
+        Format(sGameModes, sizeof(sGameModes), ",%s,", sGameModes);
+        if (StrContains(sGameModes, sGameMode, false) != -1)
+            return false;
+    }
+
+    return true;
+}
+
+void OnGamemode(const char[] output, int caller, int activator, float delay)
+{
+    if (strcmp(output, "OnCoop") == 0)
+        g_iCurrentMode = 1;
+    else if (strcmp(output, "OnSurvival") == 0)
+        g_iCurrentMode = 2;
+    else if (strcmp(output, "OnVersus") == 0)
+        g_iCurrentMode = 4;
+    else if (strcmp(output, "OnScavenge") == 0)
+        g_iCurrentMode = 8;
+}
+
+void IsAllowed()
+{
+    bool bCvarAllow = g_hCvarAllow.BoolValue;
+    bool bAllowMode = IsAllowedGameMode();
+
+    if (!g_bCvarAllow && bCvarAllow && bAllowMode)
+    {
+        g_bCvarAllow = true;
+
+        for (int i = 1; i <= MaxClients; i++)
+        {
+            if (IsClientInGame(i) && GetClientTeam(i) == 2 && IsPlayerAlive(i))
+            {
+                SDKHook(i, SDKHook_OnTakeDamage, OnTakeDamage);
+            }
+        }
+
+        HookEvent("player_spawn", Event_PlayerSpawn);
+        HookEvent("round_start", Event_RoundStart, EventHookMode_PostNoCopy);
+        HookEvent("round_end", Event_RoundEnd, EventHookMode_PostNoCopy);
+        HookEvent("mounted_gun_start", Event_MountedGun);
+        HookEvent("charger_impact", Event_ChargerImpact);
+    }
+    else if (g_bCvarAllow && (!bCvarAllow || !bAllowMode))
+    {
+        ResetPlugin();
+        g_bCvarAllow = false;
+
+        delete g_hTimerGun;
+
+        UnhookEvent("player_spawn", Event_PlayerSpawn);
+        UnhookEvent("round_start", Event_RoundStart, EventHookMode_PostNoCopy);
+        UnhookEvent("round_end", Event_RoundEnd, EventHookMode_PostNoCopy);
+        UnhookEvent("mounted_gun_start", Event_MountedGun);
+        UnhookEvent("charger_impact", Event_ChargerImpact);
+    }
+}
+
+public void OnClientPutInServer(int client)
+{
+    g_bThirdView[client] = false;
+    g_bMountedGun[client] = false;
+}
+
+public void OnClientDisconnect(int client)
+{
+    delete g_hTimerReset[client];
+}
+
+public void Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
+{
+    int client = GetClientOfUserId(event.GetInt("userid"));
+    if (client)
+    {
+        g_bThirdView[client] = false;
+        g_bMountedGun[client] = false;
+
+        SDKUnhook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+        SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+    }
+}
+
+public void Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
+{
+    delete g_hTimerGun;
+
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        g_bThirdView[i] = false;
+        g_bMountedGun[i] = false;
+    }
+}
+
+public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
+{
+    delete g_hTimerGun;
+}
+
+public void Event_ChargerImpact(Event event, const char[] name, bool dontBroadcast)
+{
+    int userid = event.GetInt("victim");
+    int client = GetClientOfUserId(userid);
+    if (client && g_bThirdView[client])
+    {
+        SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 99999.3);
+    }
+}
+
+Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
+{
+    if (g_bThirdView[victim] && damagetype == DMG_CLUB && victim > 0 && victim <= MaxClients && attacker > 0 && attacker <= MaxClients && GetClientTeam(victim) == 2 && GetClientTeam(attacker) == 3)
+    {
+        delete g_hTimerReset[victim];
+        g_hTimerReset[victim] = CreateTimer(1.0, TimerReset, GetClientUserId(victim), TIMER_REPEAT);
+        SetEntPropFloat(victim, Prop_Send, "m_TimeForceExternalView", 99999.3);
+    }
+
+    return Plugin_Continue;
+}
+
+Action TimerReset(Handle timer, any client)
+{
+    client = GetClientOfUserId(client);
+    if (client && g_bThirdView[client])
+    {
+        SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 99999.3);
+    }
+
+    g_hTimerReset[client] = null;
+    return Plugin_Stop;
+}
+
+public void Event_MountedGun(Event event, const char[] name, bool dontBroadcast)
+{
+    int client = GetClientOfUserId(event.GetInt("userid"));
+    if (g_bThirdView[client])
+    {
+        g_bMountedGun[client] = true;
+        SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 0.0);
+
+        if (g_hTimerGun == null)
+        {
+            g_hTimerGun = CreateTimer(0.5, TimerCheck, _, TIMER_REPEAT);
+        }
+    }
+}
+
+Action TimerCheck(Handle timer)
+{
+    int count;
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        if (g_bMountedGun[i] && IsClientInGame(i) && IsPlayerAlive(i))
+        {
+            if (GetEntProp(i, Prop_Send, "m_usingMountedWeapon"))
+            {
+                count++;
+            }
+            else
+            {
+                SetEntPropFloat(i, Prop_Send, "m_TimeForceExternalView", 99999.3);
+                g_bMountedGun[i] = false;
+            }
+        }
+    }
+
+    if (count)
+        return Plugin_Continue;
+
+    g_hTimerGun = null;
+    return Plugin_Stop;
+}
+
+Action CmdTP_Off(int client, int args)
+{
+    if (g_bCvarAllow && client && IsPlayerAlive(client))
+    {
+        g_bThirdView[client] = false;
+        SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 0.0);
+        PrintToChat(client, "%s%t", CHAT_TAG, "Off");
+    }
+
+    return Plugin_Handled;
+}
+
+Action CmdTP_On(int client, int args)
+{
+    if (g_bCvarAllow && client && IsPlayerAlive(client))
+    {
+        g_bThirdView[client] = true;
+        SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 99999.3);
+        PrintToChat(client, "%s%t", CHAT_TAG, "On");
+    }
+
+    return Plugin_Handled;
+}
+
+Action CmdThird(int client, int args)
+{
+    if (g_bCvarAllow && client && IsPlayerAlive(client))
+    {
+        if (!g_bThirdView[client])
+        {
+            g_bThirdView[client] = true;
+            SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 99999.3);
+            PrintToChat(client, "%s%t", CHAT_TAG, "On");
+        }
+        else
+        {
+            g_bThirdView[client] = false;
+            SetEntPropFloat(client, Prop_Send, "m_TimeForceExternalView", 0.0);
+            PrintToChat(client, "%s%t", CHAT_TAG, "Off");
+        }
+    }
+
+    return Plugin_Handled;
+}


### PR DESCRIPTION
## Summary
- bundle Silvers' survivor third-person helper plugin and drive the menu toggle through its commands
- remove the nonfunctional change-character option and rely on ExtraMenu_Close when releasing the held menu key

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e61415b9c8326adc9cf319ad93bf6)